### PR TITLE
Update admin app plugin reference

### DIFF
--- a/docs/webiny-apps/admin/development/header-elements.md
+++ b/docs/webiny-apps/admin/development/header-elements.md
@@ -6,14 +6,14 @@ sidebar_label: Header Elements
 
 One of the main sections of the Admin app is the Header, which is located on the top of the screen. By default, it contains a few header elements, for example Logo, Search bar and Settings.
 
-![Header example](/img/webiny-apps/admin/development/header/header-1.png)
+![Header example](/img/webiny-apps/admin/development/Header/header-1.png)
 
-You can easily add your own header element by registering a new `header-left`, `header-middle` or `header-right` plugin:
+You can easily add your own header element by registering a new `admin-header-left`, `admin-header-middle` or `admin-header-right` plugin:
 
 ```javascript
 {
-    type: "header-left",
-    name: "header-logo",
+    type: "admin-header-left",
+    name: "admin-header-logo",
     render() {
         return <Logo />;
     }
@@ -22,8 +22,8 @@ You can easily add your own header element by registering a new `header-left`, `
 
 ```javascript
 {
-    type: "header-middle",
-    name: "global-search",
+    type: "admin-header-middle",
+    name: "admin-global-search",
     render() {
         return <SearchBar />;
     }
@@ -32,8 +32,8 @@ You can easily add your own header element by registering a new `header-left`, `
 
 ```javascript
 {
-    type: "header-right",
-    name: "header-user-menu",
+    type: "admin-header-right",
+    name: "admin-header-user-menu",
     render() {
       return <UserMenu />;
     }
@@ -44,12 +44,12 @@ You can easily add your own header element by registering a new `header-left`, `
 
 The key property of the plugin is the `render` property, which represents a function that returns one or more React components which will render the header element.
 
-Lets add a custom component to the `header-right` element of the header elements plugin
+Lets add a custom component to the `admin-header-right` element of the header elements plugin
 
 ```javascript
 {
-  type: "header-right",
-  name: "header-logout-button",
+  type: "admin-header-right",
+  name: "admin-header-logout-button",
   render() {
     return <LogoutButton />;
   }
@@ -58,4 +58,4 @@ Lets add a custom component to the `header-right` element of the header elements
 
 After registering the above plugin, the following element should be added in the right side of the header:
 
-![header-right Registration](/img/webiny-apps/admin/development/header/header-2.png)
+![header-right Registration](/img/webiny-apps/admin/development/Header/header-2.png)

--- a/docs/webiny-apps/admin/development/menus.md
+++ b/docs/webiny-apps/admin/development/menus.md
@@ -8,12 +8,12 @@ One of the main sections of the Admin app is the main menu, which is located on 
 
 ![Menu example](/img/webiny-apps/admin/development/menus/menu-example.png)
 
-You can easily add your own menu sections and items by registering a new `menu` plugin:
+You can easily add your own menu sections and items by registering a new `admin-menu` plugin:
 
 ```javascript
 {
-  type: "menu",
-  name: "menu-shop",
+  type: "admin-menu",
+  name: "admin-menu-shop",
   render({ Menu, Section, Item }) {
     return (
       <Menu name="shop" label={"Shop"}>
@@ -32,13 +32,13 @@ You can easily add your own menu sections and items by registering a new `menu` 
 ```
 > If you are not already familiar with how plugins work, we recommend you take a look at the [Plugins Crash Course](/docs/developer-tutorials/plugins-crash-course).
 
-The key property of the plugin is the `render` property, which represents a function that returns one or more React components which will render the menu. 
+The key property of the plugin is the `render` property, which represents a function that returns one or more React components which will render the menu.
 
-The provided `Menu`, `Section`, and `Item` components will probably cover most of your needs, but note that you can still use custom ones if needed.  
+The provided `Menu`, `Section`, and `Item` components will probably cover most of your needs, but note that you can still use custom ones if needed.
 
-> You can use the `path` prop on the `Item` component in order to create links. Note that in order for them to actually work, you will also need to [create routes](/docs/webiny-apps/admin/admin/routes).  
+> You can use the `path` prop on the `Item` component in order to create links. Note that in order for them to actually work, you will also need to [create routes](/docs/webiny-apps/admin/admin/routes).
 
-After registering the above plugin, the following section should be added in the main menu: 
+After registering the above plugin, the following section should be added in the main menu:
 
 ![Menu Registration](/img/webiny-apps/admin/development/menus/new-menu-example.png)
 
@@ -51,8 +51,8 @@ import { SecureRoute } from "@webiny/app-security/components";
 ( ... )
 
 {
-    type: "menu",
-    name: "menu-shop",
+    type: "admin-menu",
+    name: "admin-menu-shop",
     render({ Menu, Section, Item }) {
         return (
             <Menu name="shop" label={"Shop"}>

--- a/docs/webiny-apps/admin/development/plugins-reference/app.md
+++ b/docs/webiny-apps/admin/development/plugins-reference/app.md
@@ -7,21 +7,21 @@ sidebar_label: App
 # Summary
 
 
-[`header-left`](/docs/webiny-apps/admin/development/plugins-reference/app#header-left)
+[`admin-header-left`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-header-left)
 
-[`header-middle`](/docs/webiny-apps/admin/development/plugins-reference/app#header-middle)
+[`admin-header-middle`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-header-middle)
 
-[`header-right`](/docs/webiny-apps/admin/development/plugins-reference/app#header-right)
+[`admin-header-right`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-header-right)
 
-[`menu`](/docs/webiny-apps/admin/development/plugins-reference/app#menu)
+[`admin-menu`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-menu)
 
 [`route`](/docs/webiny-apps/admin/development/plugins-reference/app#route)
 
 ---
 
-<!-- --------------------------------- header-left plugin --------------------------------- -->
+<!-- --------------------------------- admin-header-left plugin --------------------------------- -->
 
-### [`header-left`](/docs/webiny-apps/admin/development/plugins-reference/app#header-left)
+### [`admin-header-left`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-header-left)
 
 #### Summary
 
@@ -32,8 +32,8 @@ Enables adding custom header elements to the left side of the top bar.
 #### Type
 
 ```ts
-type HeaderLeftPlugin = Plugin & {
-    type: "header-left";
+type AdminHeaderLeftPlugin = Plugin & {
+    type: "admin-header-left";
     render(params: RenderParams): React.ReactNode;
 };
 ```
@@ -42,18 +42,18 @@ type HeaderLeftPlugin = Plugin & {
 
 ```ts
 {
-    type: "header-left",
-    name: "header-logo",
+    type: "admin-header-left",
+    name: "admin-header-logo",
     render() {
         return <Logo />;
     }
 };
 ```
 
-<!-- --------------------------------- header-middle plugin --------------------------------- -->
+<!-- --------------------------------- admin-header-middle plugin --------------------------------- -->
 
 
-### [`header-middle`](/docs/webiny-apps/admin/development/plugins-reference/app#header-middle)
+### [`admin-header-middle`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-header-middle)
 
 #### Summary
 
@@ -64,8 +64,8 @@ Enables adding custom header elements to the middle of the top bar.
 #### Type
 
 ```ts
-type HeaderMiddlePlugin = Plugin & {
-    type: "header-middle";
+type AdminHeaderMiddlePlugin = Plugin & {
+    type: "admin-header-middle";
     render(params: RenderParams): React.ReactNode;
 };
 ```
@@ -74,18 +74,18 @@ type HeaderMiddlePlugin = Plugin & {
 
 ```ts
 {
-    type: "header-middle",
-    name: "global-search",
+    type: "admin-header-middle",
+    name: "admin-global-search",
     render() {
         return <SearchBar />;
     }
 };
 ```
 
-<!-- --------------------------------- header-right plugin --------------------------------- -->
+<!-- --------------------------------- admin-header-right plugin --------------------------------- -->
 
 
-### [`header-right`](/docs/webiny-apps/admin/development/plugins-reference/app#header-right)
+### [`admin-header-right`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-header-right)
 
 #### Summary
 
@@ -96,8 +96,8 @@ Enables adding custom header elements to the right side of the top bar.
 #### Type
 
 ```ts
-type HeaderRightPlugin = Plugin & {
-    type: "header-right";
+type AdminHeaderRightPlugin = Plugin & {
+    type: "admin-header-right";
     render(params: RenderParams): React.ReactNode;
 };
 ```
@@ -106,7 +106,7 @@ type HeaderRightPlugin = Plugin & {
 
 ```ts
 {
-    type: "header-right",
+    type: "admin-header-right",
     name: "header-user-menu",
     render() {
         return <UserMenu />;
@@ -114,9 +114,9 @@ type HeaderRightPlugin = Plugin & {
 };
 ```
 
-<!-- --------------------------------- menu plugin --------------------------------- -->
+<!-- --------------------------------- admin-menu plugin --------------------------------- -->
 
-### [`menu`](/docs/webiny-apps/admin/development/plugins-reference/app#menu)
+### [`admin-menu`](/docs/webiny-apps/admin/development/plugins-reference/app#admin-menu)
 
 #### Summary
 
@@ -127,8 +127,8 @@ Enables adding custom menu sections and items in the main menu, located on the l
 #### Type
 
 ```ts
-type MenuPlugin = Plugin & {
-    type: "menu";
+type AdminMenuPlugin = Plugin & {
+    type: "admin-menu";
     render(props: {
         Menu: typeof Menu;
         Section: typeof Section;
@@ -142,8 +142,8 @@ type MenuPlugin = Plugin & {
 
 ```ts
 {
-  type: "menu",
-  name: "menu-shop",
+  type: "admin-menu",
+  name: "admin-menu-shop",
   render({ Menu, Section, Item }) {
     return (
       <Menu name="shop" label={"Shop"}>
@@ -183,7 +183,7 @@ type RoutePlugin = Plugin & {
 ```ts
 // Import the Route component from the "@webiny/react-router" package.
 import { Route } from "@webiny/react-router";
-   
+
 (...)
 
 {


### PR DESCRIPTION
In regards to issue #69
update admin app plugin reference to use `admin` prefix in case of following plugins:
- header-left
- header-middle
- header-right
- menu
