### PR TITLE
update `app-template` links

### DIFF
--- a/docs/app-development/create-app-template/basic-template.md
+++ b/docs/app-development/create-app-template/basic-template.md
@@ -94,8 +94,8 @@ You can have plugins built into your template to provide the basic functionality
 
 To see examples of more complex templates, and even template composition, see our github:
 
-- [Site app template](https://github.com/webiny/webiny-js/tree/develop/packages/app-template-site) - this template is used to bootstrap default Webiny site app.
-- [Admin app template](https://github.com/webiny/webiny-js/tree/develop/packages/app-template-admin) - this template is used to bootstrap an empty Admin app, with just the basic features like Security and File Manager.
-- [Full Webiny template](https://github.com/webiny/webiny-js/tree/develop/packages/app-template-admin-full) - this template uses [Admin app template](https://github.com/webiny/webiny-js/tree/develop/packages/app-template-admin) and adds some more plugins to it. This is a great way to reuse existing app templates and enrich them with new functionality.
+- [Site app template](https://github.com/webiny/webiny-js/tree/master/packages/app-template-site) - this template is used to bootstrap default Webiny site app.
+- [Admin app template](https://github.com/webiny/webiny-js/tree/master/packages/app-template-admin) - this template is used to bootstrap an empty Admin app, with just the basic features like Security and File Manager.
+- [Full Webiny template](https://github.com/webiny/webiny-js/tree/master/packages/app-template-admin-full) - this template uses [Admin app template](https://github.com/webiny/webiny-js/tree/master/packages/app-template-admin) and adds some more plugins to it. This is a great way to reuse existing app templates and enrich them with new functionality.
 
 Typescript makes all this even more fun: by defining your template parameter types, the user of your app template will not have to dig though your code, and instead use autocomplete and quickly learn what's possible with your app template.


### PR DESCRIPTION
Fix broken links
---
`app-template` links were pointing to `develop` branch which no longer exists. I've updated these links to point to the `master` branch.
