### PR TITLE
add dbname to monbodb-atlas guide

### DIFF
--- a/docs/guides/mongodb-atlas.md
+++ b/docs/guides/mongodb-atlas.md
@@ -50,7 +50,7 @@ Now it's time to select your connection method. For your case select the "Connec
 
 ![MongoDB Atlas Cluster Connection Method](/img/guides/mongodb-atlas/mongodb-atlas-connection-method.png)
 
-This will present you with a connection string. You want to copy that string and replace `<password>` with the password you assigned to your MongoDB user.
+This will present you with a connection string. You want to copy that string and replace `<password>` with the password you assigned to your MongoDB user, and `<dbname>` with the name of the database (the project name).
 
 ![MongoDB Atlas Cluster Connection Method](/img/guides/mongodb-atlas/mongodb-atlas-connection-string.png)
 


### PR DESCRIPTION
You might want to check this but I think MongoDB Atlas seems to have removed the `dbname` from the connection string as well as the `password`

<img width="658" alt="Screenshot 2020-08-29 at 21 10 21" src="https://user-images.githubusercontent.com/2216344/91645349-47b1e680-ea3c-11ea-9472-2f67226719c5.png">
