### PR TITLE
Change cases for reference names and fix typos

### DIFF
--- a/docs/deep-dive/architecture/files.md
+++ b/docs/deep-dive/architecture/files.md
@@ -55,7 +55,7 @@ The File service is responsible for handling file uploads, file downloads, resiz
 1. If the request is for an image for a specific image size, the **(F) File download service** will pass on the request to **(G) Image resize service**.
 
 2. **(G) Image resize service** resizes the image and saves the specific image to the **(E) S3 file storage**. 
-    - To protect agains brute-force attacks, Webiny has a fixed set of image sizes.
+    - To protect against brute-force attacks, Webiny has a fixed set of image sizes.
     - In case you request an image of 282px, Webiny will return the first greater image size.
 
 3. The image is returned to the client, by passing it to the **(A) CloudFront** CDN, where it's also cached.

--- a/docs/deep-dive/development-workflow.md
+++ b/docs/deep-dive/development-workflow.md
@@ -85,13 +85,13 @@ This is the reason we use yarn because its workspace management makes working wi
 
 Check out our [project structure](https://docs.webiny.com/docs/deep-dive/project-structure) and content here.
 
-When you navigate to `packages` you will see around 70 packages. We also have the `sample-project` folder. This is the project which the user will get when creating a new webiny project. The `sample-project` is the project we simulate users project, we will use it as a sandbox.
+When you navigate to `packages` you will see around 70 packages. We also have the `sample-project` folder. This is the project which the user will get when creating a new Webiny project. The `sample-project` is the project we simulate users project, we will use it as a sandbox.
 
 - Deploy your API by running 
 `npx webiny deploy api --env=local` from the `sample-project` folder.
 
 :::note NOTES: 
-Webiny should run from the root of the Webiny project. Since `sample-project` folder is a sandbox, this is the place to run your webiny commands from.
+Webiny should run from the root of the Webiny project. Since `sample-project` folder is a sandbox, this is the place to run your Webiny commands from.
 
 Run `npx webiny --help` to see the available commands in our CLI
 :::
@@ -118,7 +118,7 @@ Why? Because `npx` will resolve the CLI binary to the node_modules in the root o
 
  - The easiest way to run a watch is by running ```lerna run watch --scope=name_of_package --stream --parallel```.
 
-Now that we set up webiny project, we can notice that webiny is set up as a monorepo so you can manage your packages, for both API and React.
+Now that we set up Webiny project, we can notice that Webiny is set up as a monorepo so you can manage your packages, for both API and React.
 
 This is the reason we use yarn because its workspace management makes working with monorepos enjoyable.
 

--- a/docs/guides/build-a-portfolio-website-with-react-webiny-apollo.md
+++ b/docs/guides/build-a-portfolio-website-with-react-webiny-apollo.md
@@ -974,7 +974,7 @@ Run the following command:
 npm install -g vercel
 ```
 
-This command will install the vercel CLI into your local machine.
+This command will install the Vercel CLI into your local machine.
 
 Next, we will sign in into Vercel through the CLI. Run the command:
 

--- a/docs/guides/headless-nextjs-tutorial.md
+++ b/docs/guides/headless-nextjs-tutorial.md
@@ -180,7 +180,7 @@ export default function Home({ blogPostsData }) {
 
         <div className="grid">{BlogPosts}</div>
 
-        {/* remaning code removed for brevity */}
+        {/* remaining code removed for brevity */}
       </main>
     </div>
   );

--- a/docs/guides/serverless-applications/headless-cms/build-a-portfolio-website-with-react-webiny-apollo.md
+++ b/docs/guides/serverless-applications/headless-cms/build-a-portfolio-website-with-react-webiny-apollo.md
@@ -974,7 +974,7 @@ Run the following command:
 npm install -g vercel
 ```
 
-This command will install the vercel CLI into your local machine.
+This command will install the Vercel CLI into your local machine.
 
 Next, we will sign in into Vercel through the CLI. Run the command:
 

--- a/docs/guides/serverless-applications/headless-cms/headless-nextjs-tutorial.md
+++ b/docs/guides/serverless-applications/headless-cms/headless-nextjs-tutorial.md
@@ -180,7 +180,7 @@ export default function Home({ blogPostsData }) {
 
         <div className="grid">{BlogPosts}</div>
 
-        {/* remaning code removed for brevity */}
+        {/* remaining code removed for brevity */}
       </main>
     </div>
   );

--- a/docs/guides/serverless-solutions/api/building-serverless-graphql-api-webiny.md
+++ b/docs/guides/serverless-solutions/api/building-serverless-graphql-api-webiny.md
@@ -267,7 +267,7 @@ The two most essential plugins are the **graphql** and the **model** plugin. We 
 The **[models.ts](https://github.com/webiny/webiny-examples/blob/master/serverless-graphql-api/api/habits-tracker/src/plugins/models.ts)** file has a list of commodo models that we want our GraphQL to have.
 
 :::info
-[**Commodo**](https://github.com/webiny/commodo) is a set of higher order functions (HOFs) that let you define and **com**pose rich data **mod**el **o**bjects.
+[**Commodo**](https://github.com/webiny/commodo) is a set of higher order functions (HOFs) that let you define and compose rich data model objects.
 :::
 
 The Commodo library is part of the Webiny project by default. It enables you to create data models.

--- a/docs/tutorials/build-a-portfolio-website-with-react-webiny-apollo.md
+++ b/docs/tutorials/build-a-portfolio-website-with-react-webiny-apollo.md
@@ -974,7 +974,7 @@ Run the following command:
 npm install -g vercel
 ```
 
-This command will install the vercel CLI into your local machine.
+This command will install the Vercel CLI into your local machine.
 
 Next, we will sign in into Vercel through the CLI. Run the command:
 


### PR DESCRIPTION
Changed cases for references to proper noun entities "Webiny" and "Vercel" and fixed typos in the documentation