### PR TITLE
fix: replace site with website in webiny app command

### DIFF
--- a/docs/how-to-guides/deployment/deploy-your-project.mdx
+++ b/docs/how-to-guides/deployment/deploy-your-project.mdx
@@ -86,5 +86,5 @@ The following deploy commands deploy three different applications, all into the 
 ```
 yarn webiny app deploy api --env dev
 yarn webiny app deploy apps/admin --env dev
-yarn webiny app deploy apps/site --env dev
+yarn webiny app deploy apps/website --env dev
 ```

--- a/docs/how-to-guides/deployment/destroy-cloud-infrastructure.mdx
+++ b/docs/how-to-guides/deployment/destroy-cloud-infrastructure.mdx
@@ -45,5 +45,5 @@ The following destroy commands destroy cloud infrastructure deployed for three p
 ```
 yarn webiny app destroy api --env dev
 yarn webiny app destroy apps/admin --env dev
-yarn webiny app destroy apps/site --env dev
+yarn webiny app destroy apps/website --env dev
 ```


### PR DESCRIPTION
## Short Description
In few places, we still had `site` instead of `website` in `yarn webiny app ...` command.
