### PR TITLE
fix(create-an-application): links towards the introduction

### DIFF
--- a/docs/tutorials/create-an-application/admin-area-package.mdx
+++ b/docs/tutorials/create-an-application/admin-area-package.mdx
@@ -12,7 +12,7 @@ description: Quickly create and deploy Admin area package.
 
 
 ## Prerequisites
-Before you start this tutorial, make sure that you have Webiny installed and to read our [Introduction](./introduction) tutorial.
+Before you start this tutorial, make sure that you have Webiny installed and to read our [Introduction](/docs/tutorials/create-an-application/introduction) tutorial.
 
 ## Overview
 The UI scaffold is our boilerplate React application that works out of the box without you needing to actually write any code.

--- a/docs/tutorials/create-an-application/api-package.mdx
+++ b/docs/tutorials/create-an-application/api-package.mdx
@@ -12,7 +12,7 @@ description: Quickly create and deploy API package.
 
 
 ## Prerequisites
-Before you start this tutorial, make sure that you have Webiny installed and to read our [Introduction](./introduction) tutorial.
+Before you start this tutorial, make sure that you have Webiny installed and to read our [Introduction](/docs/tutorials/create-an-application/introduction) tutorial.
 
 ## Overview
 The API scaffold is our boilerplate GraphQL API that works out of the box without you needing to actually write any code.


### PR DESCRIPTION
## Short Description
Fix for a broken introduction link

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [Api package Introduction url change](https://deploy-preview-254--webiny-docs.netlify.app/docs/tutorials/create-an-application/api-package)
- [Admin module Introduction url change](https://deploy-preview-254--webiny-docs.netlify.app/docs/tutorials/create-an-application/admin-area-package)

## Checklist
- [x] I added page metadata (description, keywords)
- [x] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [x] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [x] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [x] I added `alt` / `title` attributes for inserted images (if any)