### PR TITLE
feat(key-topics): scaffold explanations

### DIFF
--- a/docs/key-topics/scaffolds/admin-area-module.mdx
+++ b/docs/key-topics/scaffolds/admin-area-module.mdx
@@ -8,7 +8,7 @@ description: How to Generate a Simple Admin Area Module
 
 
 :::tip What you'll learn
-- how to generate a simple Admin Area Module
+- how to generate a Admin Area Module
 :::
 
 ## Overview
@@ -16,7 +16,6 @@ Webiny CLI Admin Area Module Scaffold is the tool that you'll be using to genera
 It is meant to work, out of the box, with our scaffolded [GraphQL API](/docs/key-topics/scaffolds/graphql-api) as it contains the UI for all the generated API operations.
 
 Of course, you can modify it to whatever you require.
-
 
 ## Command
 

--- a/docs/key-topics/scaffolds/admin-area-module.mdx
+++ b/docs/key-topics/scaffolds/admin-area-module.mdx
@@ -8,22 +8,23 @@ description: How to Generate a Simple Admin Area Module
 
 
 :::tip What you'll learn
-- how to generate a simple admin area module
+- how to generate a simple Admin Area Module
 :::
-
-## Prerequisites
-Before you start this reading this key topic, make sure that you have Webiny installed and to read our [Webiny CLI](/docs/key-topics/webiny-cli) key topic.
 
 ## Overview
 Webiny CLI Admin Area Module Scaffold is the tool that you'll be using to generate a simple React application for our Admin Area.
 It is meant to work, out of the box, with our scaffolded [GraphQL API](/docs/key-topics/scaffolds/graphql-api) as it contains the UI for all the generated API operations.
 
-Of course, you can modify it to what ever you require.
+Of course, you can modify it to whatever you require.
 
 
 ## Command
 
-To start the scaffolding run the `yarn webiny scaffold` command and then choose the `Admin Area package` option.
+To start the scaffolding, run the command
+```
+yarn webiny scaffold
+```
+And then choose the `Admin Area package` option.
 
 ## Details
 

--- a/docs/key-topics/scaffolds/admin-area-module.mdx
+++ b/docs/key-topics/scaffolds/admin-area-module.mdx
@@ -1,0 +1,30 @@
+---
+id: admin-area-module
+title: Admin Area Module
+sidebar_label: Admin Area Module
+keywords: ["webiny", "cli", "admin", "graphql", "scaffold", "react"]
+description: How to Generate a Simple Admin Area Module
+---
+
+
+:::tip What you'll learn
+- how to generate a simple admin area module
+:::
+
+## Prerequisites
+Before you start this reading this key topic, make sure that you have Webiny installed and to read our [Webiny CLI](/docs/key-topics/webiny-cli) key topic.
+
+## Overview
+Webiny CLI Admin Area Module Scaffold is the tool that you'll be using to generate a simple React application for our Admin Area.
+It is meant to work, out of the box, with our scaffolded [GraphQL API](/docs/key-topics/scaffolds/graphql-api) as it contains the UI for all the generated API operations.
+
+Of course, you can modify it to what ever you require.
+
+
+## Command
+
+To start the scaffolding run the `yarn webiny scaffold` command and then choose the `Admin Area package` option.
+
+## Details
+
+For more details on the questions read our [Admin Area Package](/docs/tutorials/create-an-application/admin-area-package) tutorial.

--- a/docs/key-topics/scaffolds/graphql-api.mdx
+++ b/docs/key-topics/scaffolds/graphql-api.mdx
@@ -12,10 +12,10 @@ description: How to Generate a Simple GraphQL API
 :::
 
 ## Overview
-Webiny CLI GraphQL API Scaffold is the tool that you'll be using to generate a simple GraphQL API which contains basic create, update, delete, read and list operations.
+Webiny CLI GraphQL API Scaffold is the tool that you'll be using to generate a simple GraphQL API, which contains basic create, update, delete, read, and list operations.
 It also contains Elasticsearch implementation for advanced searching due to DynamoDB search is almost non-existent.
 
-You can remove the Elasticsearch code if you do not have a need for it.
+You can remove the Elasticsearch code if you do not require it.
 
 Generated code contains tests for the queries and mutations.
 

--- a/docs/key-topics/scaffolds/graphql-api.mdx
+++ b/docs/key-topics/scaffolds/graphql-api.mdx
@@ -8,15 +8,12 @@ description: How to Generate a Simple GraphQL API
 
 
 :::tip What you'll learn
-- how to generate a simple graphql api
+- how to generate a simple GraphQL API
 :::
-
-## Prerequisites
-Before you start this reading this key topic, make sure that you have Webiny installed and to read our [Webiny CLI](/docs/key-topics/webiny-cli) key topic.
 
 ## Overview
 Webiny CLI GraphQL API Scaffold is the tool that you'll be using to generate a simple GraphQL API which contains basic create, update, delete, read and list operations.
-It also contains Elasticsearch implementation for advanced searching due to DynamoDB search is, almost, non-existent.
+It also contains Elasticsearch implementation for advanced searching due to DynamoDB search is almost non-existent.
 
 You can remove the Elasticsearch code if you do not have a need for it.
 
@@ -24,7 +21,11 @@ Generated code contains tests for the queries and mutations.
 
 ## Command
 
-To start the scaffolding run the `yarn webiny scaffold` command and then choose the `GraphQL API package` option.
+To start the scaffolding, run the command:
+```
+yarn webiny scaffold
+```
+And then choose the `GraphQL API package` option.
 
 ## Details
 

--- a/docs/key-topics/scaffolds/graphql-api.mdx
+++ b/docs/key-topics/scaffolds/graphql-api.mdx
@@ -1,0 +1,31 @@
+---
+id: graphql-api
+title: GraphQL API
+sidebar_label: GraphQL API
+keywords: ["webiny", "cli", "graphql", "api", "scaffold", "dynamodb", "elasticsearch"]
+description: How to Generate a Simple GraphQL API
+---
+
+
+:::tip What you'll learn
+- how to generate a simple graphql api
+:::
+
+## Prerequisites
+Before you start this reading this key topic, make sure that you have Webiny installed and to read our [Webiny CLI](/docs/key-topics/webiny-cli) key topic.
+
+## Overview
+Webiny CLI GraphQL API Scaffold is the tool that you'll be using to generate a simple GraphQL API which contains basic create, update, delete, read and list operations.
+It also contains Elasticsearch implementation for advanced searching due to DynamoDB search is, almost, non-existent.
+
+You can remove the Elasticsearch code if you do not have a need for it.
+
+Generated code contains tests for the queries and mutations.
+
+## Command
+
+To start the scaffolding run the `yarn webiny scaffold` command and then choose the `GraphQL API package` option.
+
+## Details
+
+For more details on the questions read our [API Package](/docs/tutorials/create-an-application/api-package) tutorial.

--- a/docs/key-topics/scaffolds/react-component.mdx
+++ b/docs/key-topics/scaffolds/react-component.mdx
@@ -8,7 +8,7 @@ description: How to Generate a Simple React Component Package
 
 
 :::tip What you'll learn
-- how to generate a react component package
+- how to generate a React component package
 :::
 
 ## Prerequisites

--- a/docs/key-topics/scaffolds/react-component.mdx
+++ b/docs/key-topics/scaffolds/react-component.mdx
@@ -8,7 +8,7 @@ description: How to Generate a Simple React Component Package
 
 
 :::tip What you'll learn
-- how to generate a simple admin area module
+- how to generate a react component package
 :::
 
 ## Prerequisites

--- a/docs/key-topics/scaffolds/react-component.mdx
+++ b/docs/key-topics/scaffolds/react-component.mdx
@@ -8,27 +8,28 @@ description: How to Generate a Simple React Component Package
 
 
 :::tip What you'll learn
-- how to generate a React component package
+- how to generate a React Component Package
 :::
 
-## Prerequisites
-Before you start this reading this key topic, make sure that you have Webiny installed and to read our [Webiny CLI](/docs/key-topics/webiny-cli) key topic.
-
 ## Overview
-Webiny CLI Simple React Component Scaffold is the tool that you'll be using to generate a React component package.
+Webiny CLI Simple React Component Package Scaffold is the tool that you'll be using to generate a React component package.
 
 It generates a React component, links it in the `node_modules` and exports it for usage in your applications.
 
-Of course, you can modify it to what ever you require.
+Of course, you can modify it to whatever you require.
 
 
 ## Command
 
-To start the scaffolding run the `yarn webiny scaffold` command and then choose the `Simple React component package` option.
+To start the scaffolding, run the command:
+```
+yarn webiny scaffold
+```
+And then choose the `Simple React component package` option.
 
 ## Details
 
-There are few questions that you will need to go through before actual component is generated. Questions are:
+There are a few questions that you will need to go through before the actual component is generated. Questions are:
 
 #### 1. Enter the name of the component (in pascal-case)
 The name of your component. It is used when importing the component from the package and in some parts of the code.
@@ -39,6 +40,7 @@ The location of your component from the root of the project.
 By the default location is `packages/your-component-name`, where `your-component-name` is kebab-cased name that you have given in the previous answer.
 
 #### 3. Enter the package name
-The full package name of your component. It is used for the import of the component in the package and when publishing to the registry.
+The full package name of your component.
+It is used for the import of the component in the package and when publishing to the registry.
 
 By the default package name is `@custom-components/your-component-name`, where `your-component-name` is kebab-cased name that you have given in the first answer.

--- a/docs/key-topics/scaffolds/react-component.mdx
+++ b/docs/key-topics/scaffolds/react-component.mdx
@@ -1,0 +1,44 @@
+---
+id: react-component
+title: Simple React Component Package
+sidebar_label: Simple React Component Package
+keywords: ["webiny", "cli", "scaffold", "react"]
+description: How to Generate a Simple React Component Package
+---
+
+
+:::tip What you'll learn
+- how to generate a simple admin area module
+:::
+
+## Prerequisites
+Before you start this reading this key topic, make sure that you have Webiny installed and to read our [Webiny CLI](/docs/key-topics/webiny-cli) key topic.
+
+## Overview
+Webiny CLI Simple React Component Scaffold is the tool that you'll be using to generate a React component package.
+
+It generates a React component, links it in the `node_modules` and exports it for usage in your applications.
+
+Of course, you can modify it to what ever you require.
+
+
+## Command
+
+To start the scaffolding run the `yarn webiny scaffold` command and then choose the `Simple React component package` option.
+
+## Details
+
+There are few questions that you will need to go through before actual component is generated. Questions are:
+
+#### 1. Enter the name of the component (in pascal-case)
+The name of your component. It is used when importing the component from the package and in some parts of the code.
+
+#### 2. Enter the package location
+The location of your component from the root of the project.
+
+By the default location is `packages/your-component-name`, where `your-component-name` is kebab-cased name that you have given in the previous answer.
+
+#### 3. Enter the package name
+The full package name of your component. It is used for the import of the component in the package and when publishing to the registry.
+
+By the default package name is `@custom-components/your-component-name`, where `your-component-name` is kebab-cased name that you have given in the first answer.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -89,8 +89,8 @@ module.exports = {
                     type: "category",
                     label: "Development",
                     items: [
-                        "how-to-guides/development/environment-variables",
-                       /* {
+                        "how-to-guides/development/environment-variables"
+                        /* {
                             type: "category",
                             label: "Workflows",
                             items: [
@@ -204,7 +204,16 @@ module.exports = {
                 },
                 "key-topics/tools-libraries",
                 "key-topics/ci-cd",
-                "key-topics/webiny-cli"
+                "key-topics/webiny-cli",
+                {
+                    type: "category",
+                    label: "Scaffolding",
+                    items: [
+                        "key-topics/scaffolds/graphql-api",
+                        "key-topics/scaffolds/admin-area-module",
+                        "key-topics/scaffolds/react-component"
+                    ]
+                }
             ],
             References: [
                 {
@@ -223,7 +232,7 @@ module.exports = {
             Contributing: ["contributing/documentation", "contributing/new-page-template"]
         },
         {
-            "Changelog": ["changelog/5.3.0"]
+            Changelog: ["changelog/5.3.0"]
         },
         "webiny-telemetry"
     ]


### PR DESCRIPTION
## Short Description
Add a section in the Key Topics which explains our existing scaffolds. We need a place where we will put the list of all of our scaffolds with some explanation of them.

## Relevant Links
- [GraphQL API Scaffold](https://deploy-preview-259--webiny-docs.netlify.app/docs/key-topics/scaffolds/graphql-api)
- [Admin Area Module Scaffold](https://deploy-preview-259--webiny-docs.netlify.app/docs/key-topics/scaffolds/admin-area-module)
- [Simple React Component Scaffold](https://deploy-preview-259--webiny-docs.netlify.app/docs/key-topics/scaffolds/react-component)

## Checklist
- [x] I added page metadata (description, keywords)
- [x] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [x] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [x] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [x] I added `alt` / `title` attributes for inserted images (if any)
