### PR TITLE
fix: target property in PbEditorPageElementPlugin example 

### DIFF
--- a/docs/tutorials/page-builder/create-a-new-page-builder-element.mdx
+++ b/docs/tutorials/page-builder/create-a-new-page-builder-element.mdx
@@ -149,7 +149,7 @@ export default () => {
         }
       },
       settings: ["pb-editor-page-element-settings-delete"],
-      target: ["row", "column"],
+      target: ["cell", "block"],
       onCreate: "open-settings",
       create(options) {
         /*


### PR DESCRIPTION
## Short Description
Fix one bug in the code example of [create a new page builder element](https://www.webiny.com/docs/tutorials/page-builder/create-a-new-page-builder-element#overview) tutorial.
