### PR TITLE
feat: add install and build steps in create a new Page Builder element tutorial

### DIFF
--- a/docs/tutorials/page-builder/create-a-new-page-builder-element.mdx
+++ b/docs/tutorials/page-builder/create-a-new-page-builder-element.mdx
@@ -97,6 +97,20 @@ In the end the folder structure of our project will look similar to this:
 └── yarn.lock
 ```
 
+3. **How to create a package in webiny project**
+
+We recommend reading the [create a package in webiny project](https://www.webiny.com/docs/tutorials/create-a-package-in-webiny-project/#preparing-the-package-for-usage)
+article, in which we explain the organization of package files in detail.
+
+:::note
+Before using the `iframeElement` that we're about to build in this tutorial, you need to perform the following two steps:
+- Install the package using ```yarn install```
+- Build the package using ```yarn build```
+
+Learn more about preparing the package for usage in the [create a package in webiny project](https://www.webiny.com/docs/tutorials/create-a-package-in-webiny-project/#preparing-the-package-for-usage) tutorial.
+:::
+
+
 ## Creating the Plugins
 
 All of the available page elements can be accessed via the elements menu, which can be opened by clicking on the "plus" icon, located on the left side of the editor:


### PR DESCRIPTION
## Short Description
This PR adds the missing information about the `install` and `build` of a new package in webiny project.

## Relevant Links
- [Updated the prerequisites section of create a new page builder element page](https://deploy-preview-273--webiny-docs.netlify.app/docs/tutorials/page-builder/create-a-new-page-builder-element#prerequisites)
## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)

