### PR TITLE
fix(headless-cms): wrong webiny commands

### DIFF
--- a/docs/tutorials/headless-cms/create-a-webiny-headless-cms-address-field-plugin.mdx
+++ b/docs/tutorials/headless-cms/create-a-webiny-headless-cms-address-field-plugin.mdx
@@ -379,18 +379,8 @@ export default [
 
 
 :::danger
-Do not forget to rebuild, redeploy and rerun your application.
+Do not forget to redeploy the API and rerun or redeploy your application.
 :::
-
-```shell title="build api-headless-cms package"
-cd your-project-root
-yarn webiny ws run build --folder=packages/api-headless-cms
-```
-
-```shell title="build app-headless-cms package"
-cd your-project-root
-yarn webiny ws run build --folder=packages/app-headless-cms
-```
 
 ```shell title="redeploy your api"
 cd your-project-root

--- a/docs/tutorials/headless-cms/create-a-webiny-headless-cms-address-field-plugin.mdx
+++ b/docs/tutorials/headless-cms/create-a-webiny-headless-cms-address-field-plugin.mdx
@@ -51,6 +51,8 @@ For quick info on required plugins check our [How-to Guide: Create a Webiny Head
 First we need to create a field definition plugin. The base for the plugin is:
 
 ```tsx title="[UI]/addressFieldPlugin.tsx"
+import {CmsEditorFieldTypePlugin} from "@webiny/app-headless-cms/types";
+
 export default(): CmsEditorFieldTypePlugin => ({
     type: "cms-editor-field-type",
     name: "cms-editor-field-type-address",
@@ -86,6 +88,8 @@ Now we can create the second UI plugin, a renderer for the field we just created
 A base for the renderer plugin is:
 
 ```tsx title="[UI]/addressFieldRendererPlugin.tsx"
+import {CmsEditorFieldRendererPlugin} from "@webiny/app-headless-cms/types";
+
 export default(): CmsEditorFieldRendererPlugin => ({
     type: "cms-editor-field-renderer",
     name: "cms-editor-field-renderer-address",
@@ -138,6 +142,8 @@ Now let's go solve the API plugins. First we need to create a plugin of type `Cm
 This is the base of that plugin:
 
 ```ts title="[API]/addressFieldPlugin.ts"
+import {CmsModelFieldToGraphQLPlugin} from "@webiny/api-headless-cms/types";
+
 export default(): CmsModelFieldToGraphQLPlugin => ({
     type: "cms-model-field-to-graphql",
     name: "cms-model-field-to-graphql-address",
@@ -223,6 +229,8 @@ manage: {
 Now we have everything required to create and save the field. Next thing we need is to prevent the indexing of the field. By default, if a field is not searchable it is removed from the index. But for this tutorial we can create our own plugin. This is the base of that plugin:
 
 ```ts title="[API]/addressFieldIndexPlugin.ts"
+import {CmsModelFieldToElasticsearchPlugin} from "@webiny/api-headless-cms/types";
+
 export default (): CmsModelFieldToElasticsearchPlugin => ({
     type: "cms-model-field-to-elastic-search",
     name: "cms-model-field-to-elastic-search-address",
@@ -271,6 +279,8 @@ This plugin now does what we want - disables the field indexing. Of course, we c
 All we have left to write is the plugin for storage. As we said, we want to encrypt the data for the storage. You can what ever library you want, it is all up to you. For this tutorial we can use some custom `encrypt` and `decrypt` functions. The base of the plugin looks like this:
 
 ```ts title="[API]/addressFieldStoragePlugin.ts"
+import {CmsModelFieldToStoragePlugin} from "@webiny/api-headless-cms/types";
+
 export default (): CmsModelFieldToStoragePlugin => ({
     type: "cms-model-field-to-storage",
     name: "cms-model-field-to-storage-address",


### PR DESCRIPTION
## Issue
https://github.com/webiny/webiny-js/issues/1616

## Short Description
A fix of the wrong webiny commands in the Tutorials / Headless CMS / Create a Webiny Headless CMS address field plugin.
Also added imports to the examples.

## Relevant Links
- [Create a Webiny Headless CMS address field plugin](https://deploy-preview-282--webiny-docs.netlify.app/docs/tutorials/headless-cms/create-a-webiny-headless-cms-address-field-plugin)

## Checklist
- [x] I added page metadata (description, keywords)
- [x] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [x] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [x] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [x] I added `alt` / `title` attributes for inserted images (if any)
