### PR TITLE
Webiny 5.10.0

### DIFF
--- a/docs/changelog/5.10.0.mdx
+++ b/docs/changelog/5.10.0.mdx
@@ -24,10 +24,23 @@ Please check the [Webiny 5.10.0 migration guide](/docs/how-to-guides/upgrade-web
 
 ## Development
 
-### Minor Scaffolding Improvements([#222](https://github.com/webiny/webiny-js/pull/222))
+### Admin Area React Application - Reduced Deployment Time ([#1740](https://github.com/webiny/webiny-js/pull/1740))
 
-✍️
+Prior to this release, every time we'd deploy the Admin Area project application and its React application, all of the production build files (JS, CSS, images) would be re-uploaded from scratch. This would happen even in cases where there are no changes between the files.
 
-### Improved Admin React Application Deployment([#333](https://github.com/webiny/webiny-js/pull/333))
+From now on, files whose content didn't change simply won't be uploaded. This will significantly speed up the deployment of the Admin Area project application.
 
-✍️
+
+### Improved Existing Scaffolds ([#1739](https://github.com/webiny/webiny-js/pull/1739))
+
+A couple of minor fixes and improvements were made to the [scaffolding utilities](/docs/how-to-guides/webiny-cli/scaffolding/introduction), introduced in the previous [Webiny 5.9.0](/docs/changelog/5.9.0) release.
+
+Maybe the most significant change would be the default path, in which the application code will be generated. For example, when running the [Extend GraphQL API](/docs/how-to-guides/webiny-cli/scaffolding/extend-graphql-api), we've changed the `api/code/graphql/src/plugins/scaffolds/graphql` to `api/code/graphql/src/plugins/scaffolds`. So, we've decided to remove the trailing `graphql` folder, simply because we've noticed it's unnecessary.
+
+For other changes, please see the [linked PR](https://github.com/webiny/webiny-js/pull/1739).
+
+<!-- https://github.com/webiny/webiny-js/pull/1755 -->
+<!-- https://github.com/webiny/webiny-js/pull/1753 -->
+<!-- https://github.com/webiny/webiny-js/pull/1752 -->
+<!-- https://github.com/webiny/webiny-js/pull/1746 -->
+<!-- https://github.com/webiny/webiny-js/pull/1740 -->

--- a/docs/changelog/5.10.0.mdx
+++ b/docs/changelog/5.10.0.mdx
@@ -18,29 +18,78 @@ Please check the [Webiny 5.10.0 migration guide](/docs/how-to-guides/upgrade-web
 
 ## Page Builder
 
-### Minor Scaffolding Improvements([#111](https://github.com/webiny/webiny-js/pull/111))
+### Website Fixes ([#1746](https://github.com/webiny/webiny-js/pull/1746), [#1752](https://github.com/webiny/webiny-js/pull/1752), [#1755](https://github.com/webiny/webiny-js/pull/1755))
 
-✍️
+We discovered a couple of issues that would sometimes occur while the user is navigating through the public website.
+
+First of all, a really easy-to-miss Apollo cache-related issue would sometimes cause the pages to stop being shown correctly, forcing the user to refresh the page. We believe the changes we made in [#1746](https://github.com/webiny/webiny-js/pull/1746/files) will fully address this.
+
+We should also mention that we've managed to revisit the existing Pages List page element and that all of the community-reported issues were resolved. For more information, please check linked pull requests.
+
+### Preloading and Caching Improvements ([#1753](https://github.com/webiny/webiny-js/pull/1753))
+
+The following improvements should improve the page load times for pages created with [Webiny Page Builder](https://www.webiny.com/serverless-app/page-builder).
+
+#### Asset Preloading
+
+Once a page has been published, in the static page generation process that follows, all links to JS and CSS files will now utilize the [`rel="preload"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload) attribute :
+
+> The preload value of the `<link>` element's rel attribute lets you declare fetch requests in the HTML's `<head>`, specifying resources that your page will need very soon, which you want to start loading early in the page lifecycle, before browsers' main rendering machinery kicks in. This ensures they are available earlier and are less likely to block the page's render, improving performance.
+
+Except redeploying your project, no special steps are needed in order to receive this improvement.
+
+To double-check whether this new improvement is working as expected, open the source code of any published page in your browser. In the `<head>` section, you should be able to see the new `rel="preload"` attributes, for example:
+
+```html {4,5,6,7}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <link as="style" rel="preload" href="/static/css/2.1edd21d9.chunk.css" />
+    <link as="style" rel="preload" href="/static/css/main.30bba61e.chunk.css" />
+    <link as="script" rel="preload" href="/static/js/2.229acfe0.chunk.js" />
+    <link as="script" rel="preload" href="/static/js/main.680e9d72.chunk.js" />
+    <meta charset="utf-8" />
+    (...)
+```
+
+#### Added Missing `Cache-Control` Response Headers
+
+Upon visiting any published page, all of the static JS, CSS, and images that are part of the Website React application's production build, will now be served with proper [`Cache-Control`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) headers. Ultimately, once downloaded, these files will now be kept in browser's cache, making subsequent website renders noticeably faster.
 
 ## Development
 
 ### Admin Area React Application - Reduced Deployment Time ([#1740](https://github.com/webiny/webiny-js/pull/1740))
 
-Prior to this release, every time we'd deploy the Admin Area project application and its React application, all of the production build files (JS, CSS, images) would be re-uploaded from scratch. This would happen even in cases where there are no changes between the files.
+Prior to this release, every time we'd deploy the **Admin Area** project application ([`apps/admin`](https://github.com/webiny/webiny-js/tree/v5.10.0-beta.0/packages/cwp-template-aws/template/apps/admin/)), all of the React application's production build files (JS, CSS, images) would be re-uploaded from scratch, even if we didn't perform any changes in our application code.
 
-From now on, files whose content didn't change simply won't be uploaded. This will significantly speed up the deployment of the Admin Area project application.
+From now on, files whose content didn't change simply won't be uploaded. This will significantly speed up the deployment of the **Admin Area** project application.
 
+:::info Project Applications
+Learn more about project applications and project organization in general, in the [Project Applications and Packages](/docs/key-topics/project-organization/project-applications-and-packages) key topic.
+:::
 
 ### Improved Existing Scaffolds ([#1739](https://github.com/webiny/webiny-js/pull/1739))
 
 A couple of minor fixes and improvements were made to the [scaffolding utilities](/docs/how-to-guides/webiny-cli/scaffolding/introduction), introduced in the previous [Webiny 5.9.0](/docs/changelog/5.9.0) release.
 
-Maybe the most significant change would be the default path, in which the application code will be generated. For example, when running the [Extend GraphQL API](/docs/how-to-guides/webiny-cli/scaffolding/extend-graphql-api), we've changed the `api/code/graphql/src/plugins/scaffolds/graphql` to `api/code/graphql/src/plugins/scaffolds`. So, we've decided to remove the trailing `graphql` folder, simply because we've noticed it's unnecessary.
+For example, if you already had the chance to use the [Extend GraphQL API](/docs/how-to-guides/webiny-cli/scaffolding/extend-graphql-api) scaffold, you might notice that the default location in which the application code is generated has been changed:
 
-For other changes, please see the [linked PR](https://github.com/webiny/webiny-js/pull/1739).
+```bash
+# Previously, all of the application code would be generated within the following path:
+api/code/graphql/src/plugins/scaffolds/graphql/carManufacturers
 
-<!-- https://github.com/webiny/webiny-js/pull/1755 -->
-<!-- https://github.com/webiny/webiny-js/pull/1753 -->
-<!-- https://github.com/webiny/webiny-js/pull/1752 -->
-<!-- https://github.com/webiny/webiny-js/pull/1746 -->
-<!-- https://github.com/webiny/webiny-js/pull/1740 -->
+# This is the new path, without the "graphql" folder:
+api/code/graphql/src/plugins/scaffolds/carManufacturers
+```
+
+The same change was applied to the [Extend Admin Area](/docs/how-to-guides/webiny-cli/scaffolding/extend-admin-area) scaffold, where the redundant `admin` folder was removed:
+
+```bash
+# Previously, all of the application code would be generated within the following path:
+apps/admin/code/src/plugins/scaffolds/admin/carManufacturers
+
+# This is the new path, without the "graphql" folder:
+apps/admin/code/src/plugins/scaffolds/carManufacturers
+```
+
+For other related changes, please see the linked pull request.

--- a/docs/changelog/5.10.0.mdx
+++ b/docs/changelog/5.10.0.mdx
@@ -16,6 +16,14 @@ Please check the [Webiny 5.10.0 migration guide](/docs/how-to-guides/upgrade-web
 
 :::
 
+## Infrastructure
+
+### Node 12 Runtime and a New Sharp Layer ([#1738](https://github.com/webiny/webiny-js/pull/1738))
+
+With AWS deprecating Node 10 Lambda runtime, we've also upgraded all of our Lambda functions to use Node 12 (you may have noticed that File Manager Lambdas were using node 10). With that, we also released a new version of Sharp layer, which is twice smaller, and also supports Node 14, so we have the peace of mind for the near future.
+
+The upgrade process will take care of the existing projects and will link your existing Lambdas with the new Sharp layer, and switch to Node 12.
+
 ## Page Builder
 
 ### Website Fixes ([#1746](https://github.com/webiny/webiny-js/pull/1746), [#1752](https://github.com/webiny/webiny-js/pull/1752), [#1755](https://github.com/webiny/webiny-js/pull/1755))

--- a/docs/changelog/5.10.0.mdx
+++ b/docs/changelog/5.10.0.mdx
@@ -1,0 +1,33 @@
+---
+id: 5.10.0
+title: Webiny 5.10.0
+sidebar_label: "5.10.0"
+keywords: ["webiny", "version", "5.10.0", "changelog"]
+description: See what's new in Webiny version 5.10.0.
+---
+
+# Changes
+
+This document highlights the most important fixes, improvements, and features, that were introduced in Webiny `5.10.0`.
+
+:::info How To Upgrade?
+
+Please check the [Webiny 5.10.0 migration guide](/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0) for the upgrade steps.
+
+:::
+
+## Page Builder
+
+### Minor Scaffolding Improvements([#111](https://github.com/webiny/webiny-js/pull/111))
+
+✍️
+
+## Development
+
+### Minor Scaffolding Improvements([#222](https://github.com/webiny/webiny-js/pull/222))
+
+✍️
+
+### Improved Admin React Application Deployment([#333](https://github.com/webiny/webiny-js/pull/333))
+
+✍️

--- a/docs/changelog/5.9.0.mdx
+++ b/docs/changelog/5.9.0.mdx
@@ -28,12 +28,9 @@ For this release, we've gone through a complete overhaul of the existing **Graph
 
 <CenteredImage title="Improved Scaffolding" src={scaffolds} />
 
-<!--
-
 :::tip
-To learn more about the changes we made and the reasoning behind them, check out the dedicated [Webiny 5.9.0 - Improved Scaffolding](#) blog post.
+To learn more about the changes we made and the reasoning behind them, check out the dedicated [Webiny 5.9.0 - Improved Scaffolding](https://www.webiny.com/blog/webiny-v5.9.0-improved-scaffolds-and-development) blog post.
 :::
- -->
 
 :::info
 To learn more about scaffolding and all of the available scaffolds, check out the [Scaffolding](/docs/how-to-guides/webiny-cli/scaffolding/introduction) how-to guides section.

--- a/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
+++ b/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
@@ -22,16 +22,10 @@ Make sure to check out the [5.10.0 changelog](/docs/changelog/5.10.0) to get fam
 
 ## 1. Project Preparation
 
-First, we need to prepare your project for the upgrade process. With security packages refactor, some packages no longer exist, and if we try to upgrade dependencies straight away, `yarn` will complain. To fix that, we need to clean up your project first, to eliminate references to those deprecated packages.
-
-Also, we changed the name of our shared Elasticsearch package from `api-plugin-elastic-search-client` to `api-elasticsearch`, and we have prepared a gist for that as well.
+First, we need to prepare your project for the upgrade process.
+We changed the name of our shared Elasticsearch package from `api-plugin-elastic-search-client` to `api-elasticsearch`, and we have prepared a gist for that.
 
 In your project root, run the following:
-
-```bash
-npx https://gist.github.com/Pavel910/abc4c063eae8c18754d6a026d1fc1d06
-```
-For the Elasticsearch package change, run the following:
 ```bash
 npx https://gist.github.com/brunozoric/96e66c47abc6769947034fe707138cda
 ```
@@ -60,17 +54,7 @@ yarn webiny upgrade 5.10.0
 
 The upgrade script will make a couple of changes to your existing **API** project application's code (located within the `api` folder). Once the upgrade command has finished, you can run the [`git status`](https://git-scm.com/docs/git-status) command to see all changes that the command performed.
 
-## 4. Post Upgrade Script
-
-To finalize the upgrade, run the following command:
-
-```bash
-npx https://gist.github.com/Pavel910/4a7a9694945fffcc65b293de8091116b
-```
-
-This takes care of a small glitch in the upgrade process, which we noticed _after_ we released the 5.10.0 code. Gists to the rescue!
-
-## 5. Deploy Your Project
+## 4. Deploy Your Project
 
 Finally, proceed by re-deploying your Webiny project:
 
@@ -89,18 +73,4 @@ Learn more about different deployment environments in the [CI/CD / Environments]
 
 ## Additional Steps and Notes
 
-### GraphQL API Package Scaffold
 
-If you've been using the **GraphQL API Package** scaffold in your Webiny project prior to the `5.10.0` release, you will have to revisit the created [`types.ts`](https://github.com/webiny/webiny-js/blob/v5.9.0/packages/cli-plugin-scaffold-graphql-service/template/src/types.ts#L7) file for each created package, and replace the following line:
-
-```ts
-import { TenancyContext } from "@webiny/api-security-tenancy/types";
-```
-
-Replace it with the following import statement:
-
-```ts
-import { TenancyContext } from "@webiny/api-tenancy/types";
-```
-
-This change is required simply because the `@webiny/api-security-tenancy` package doesn't exist anymore. Note that the new `@webiny/api-tenancy` package should already exist in your project, so there's no need to add it manually.

--- a/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
+++ b/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
@@ -23,9 +23,10 @@ Make sure to check out the [5.10.0 changelog](/docs/changelog/5.10.0) to get fam
 ## 1. Project Preparation
 
 First, we need to prepare your project for the upgrade process.
-We changed the name of our shared Elasticsearch package from `api-plugin-elastic-search-client` to `api-elasticsearch`, and we have prepared a gist for that.
+We renamed our shared Elasticsearch package from `api-plugin-elastic-search-client` to `api-elasticsearch`, and we need to update package.json files that are using it, before attempting to upgrade packages using `yarn`.
 
 In your project root, run the following:
+
 ```bash
 npx https://gist.github.com/brunozoric/96e66c47abc6769947034fe707138cda
 ```
@@ -70,7 +71,3 @@ As stated in the [Overview](/docs/how-to-guides/upgrade-webiny/overview#pre-prod
 :::tip
 Learn more about different deployment environments in the [CI/CD / Environments](/docs/key-topics/ci-cd/environments) key topic.
 :::
-
-## Additional Steps and Notes
-
-

--- a/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
+++ b/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
@@ -24,10 +24,16 @@ Make sure to check out the [5.10.0 changelog](/docs/changelog/5.10.0) to get fam
 
 First, we need to prepare your project for the upgrade process. With security packages refactor, some packages no longer exist, and if we try to upgrade dependencies straight away, `yarn` will complain. To fix that, we need to clean up your project first, to eliminate references to those deprecated packages.
 
+Also, we changed the name of our shared Elasticsearch package from `api-plugin-elastic-search-client` to `api-elasticsearch`, and we have prepared a gist for that as well.
+
 In your project root, run the following:
 
 ```bash
 npx https://gist.github.com/Pavel910/abc4c063eae8c18754d6a026d1fc1d06
+```
+For the Elasticsearch package change, run the following:
+```bash
+npx https://gist.github.com/brunozoric/96e66c47abc6769947034fe707138cda
 ```
 
 ## 2. Upgrade Webiny Packages

--- a/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
+++ b/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0.mdx
@@ -1,0 +1,100 @@
+---
+id: 5.9.0-to-5.10.0
+title: Upgrade from 5.9.0 to 5.10.0
+sidebar_label: 5.9.0 → 5.10.0
+keywords: ["webiny", "version", "upgrade", "5.9.0", "5.10.0"]
+description: Learn how to upgrade Webiny from 5.9.0 to 5.10.0.
+---
+
+:::tip What you’ll learn
+
+- how to upgrade Webiny from 5.9.0 to 5.10.0
+
+:::
+
+:::danger
+Before continuing, make sure to take the necessary precautions, listed in the [Overview](/docs/how-to-guides/upgrade-webiny/overview#-precaution-measures) section.
+:::
+
+:::info
+Make sure to check out the [5.10.0 changelog](/docs/changelog/5.10.0) to get familiar with all the changes introduced in this release.
+:::
+
+## 1. Project Preparation
+
+First, we need to prepare your project for the upgrade process. With security packages refactor, some packages no longer exist, and if we try to upgrade dependencies straight away, `yarn` will complain. To fix that, we need to clean up your project first, to eliminate references to those deprecated packages.
+
+In your project root, run the following:
+
+```bash
+npx https://gist.github.com/Pavel910/abc4c063eae8c18754d6a026d1fc1d06
+```
+
+## 2. Upgrade Webiny Packages
+
+We're now ready to upgrade all `@webiny/*` packages! Run the following command:
+
+```bash
+yarn up "@webiny/*@5.10.0"
+```
+
+Once the upgrade has finished, running the `yarn webiny --version` command in your terminal should return `5.10.0`.
+
+:::info
+Before moving on, make sure you commit all your changes.
+:::
+
+## 3. Run the Upgrade Command
+
+Now let's run the project upgrade:
+
+```bash
+yarn webiny upgrade 5.10.0
+```
+
+The upgrade script will make a couple of changes to your existing **API** project application's code (located within the `api` folder). Once the upgrade command has finished, you can run the [`git status`](https://git-scm.com/docs/git-status) command to see all changes that the command performed.
+
+## 4. Post Upgrade Script
+
+To finalize the upgrade, run the following command:
+
+```bash
+npx https://gist.github.com/Pavel910/4a7a9694945fffcc65b293de8091116b
+```
+
+This takes care of a small glitch in the upgrade process, which we noticed _after_ we released the 5.10.0 code. Gists to the rescue!
+
+## 5. Deploy Your Project
+
+Finally, proceed by re-deploying your Webiny project:
+
+```bash
+# Execute in your project root.
+yarn webiny deploy --env {environment}
+```
+
+:::caution
+As stated in the [Overview](/docs/how-to-guides/upgrade-webiny/overview#pre-production-environments-first) section, we recommend that you first deploy your changes into one of your pre-production environments, like `dev` or `staging`.
+:::
+
+:::tip
+Learn more about different deployment environments in the [CI/CD / Environments](/docs/key-topics/ci-cd/environments) key topic.
+:::
+
+## Additional Steps and Notes
+
+### GraphQL API Package Scaffold
+
+If you've been using the **GraphQL API Package** scaffold in your Webiny project prior to the `5.10.0` release, you will have to revisit the created [`types.ts`](https://github.com/webiny/webiny-js/blob/v5.9.0/packages/cli-plugin-scaffold-graphql-service/template/src/types.ts#L7) file for each created package, and replace the following line:
+
+```ts
+import { TenancyContext } from "@webiny/api-security-tenancy/types";
+```
+
+Replace it with the following import statement:
+
+```ts
+import { TenancyContext } from "@webiny/api-tenancy/types";
+```
+
+This change is required simply because the `@webiny/api-security-tenancy` package doesn't exist anymore. Note that the new `@webiny/api-tenancy` package should already exist in your project, so there's no need to add it manually.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -194,6 +194,7 @@ module.exports = {
                     label: "Upgrade Webiny",
                     items: [
                         "how-to-guides/upgrade-webiny/overview",
+                        "how-to-guides/upgrade-webiny/5.9.0-to-5.10.0",
                         "how-to-guides/upgrade-webiny/5.8.0-to-5.9.0",
                         "how-to-guides/upgrade-webiny/5.7.0-to-5.8.0",
                         "how-to-guides/upgrade-webiny/5.6.0-to-5.7.0",
@@ -327,6 +328,7 @@ module.exports = {
         },
         {
             Changelog: [
+                "changelog/5.10.0",
                 "changelog/5.9.0",
                 "changelog/5.8.0",
                 "changelog/5.7.0",


### PR DESCRIPTION
Creates the Webiny 5.10.0 changelog and upgrade guide.

[Upgrade guide](https://deploy-preview-305--webiny-docs.netlify.app/docs/how-to-guides/upgrade-webiny/5.9.0-to-5.10.0)
[Changelog](https://deploy-preview-305--webiny-docs.netlify.app/docs/changelog/5.10.0)