### PR TITLE
docs: updated reqs for the installation of this scaffold - private repos only supported under GH Ent accounts

### DIFF
--- a/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
+++ b/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
@@ -69,13 +69,6 @@ The created workflow files follow workflows described in the [CI/CD](/docs/key-t
 
 :::info
 Workflows rely on [GitHub Environments](https://docs.github.com/en/actions/reference/environments) in order to establish environment protection rules and store all of the necessary secrets, for example AWS credentials or [Pulumi Backend](/docs/key-topics/ci-cd/cloud-infrastructure-state-files#using-different-backends).
-
-[GitHub Environments](https://docs.github.com/en/actions/reference/environments) are only available in public repositories - for all GitHub products - or private repositories in GitHub Enterprise.
-If you're running a private repository in a non-GitHub Enterprise account, you will get the following installation error:
-```console
-✘ Creation of pr, dev, staging, and prod code repository environments failed with the following message: Not Found
-```
-Without Environments set up the system will use the same credentials to deploy to all environments.
 :::
 
 #### Next Steps

--- a/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
+++ b/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
@@ -14,12 +14,6 @@ import ghActions from "./ci-cd/gh_actions_logo.png";
 
 This feature is available since **v5.7.0**.
 
-You're using a **public repo** or a **private repo under a GitHub Enterprise** account.  
-The current GitHub CI/CD set up relies on [GitHub Environments](https://docs.github.com/en/actions/reference/environments). Environments are only available in public repositories - for all GitHub products - or private repositories in GitHub Enterprise.
-If you're running a private repository in a non-GitHub Enterprise account, you will get the following installation error, and **won't be able to use this scaffold today**.
-```console
-✘ Creation of pr, dev, staging, and prod code repository environments failed with the following message: Not Found
-```
 :::
 
 :::tip What you'll learn
@@ -55,6 +49,16 @@ If you plan to use a different CI/CD provider, you can still create your workflo
 </a>
 
 [GitHub Actions](https://github.com/features/actions) are often a good choice when it comes to setting up your own CI/CD, simply because of its tight integration with other existing GitHub concepts and resources.
+
+:::info Can I use this?
+
+You must be running a **public repo** or a **private repo under a GitHub Enterprise** account.  
+The current GitHub CI/CD set up relies on [GitHub Environments](https://docs.github.com/en/actions/reference/environments). Environments are only available in public repositories - for all GitHub products - or private repositories in GitHub Enterprise.
+If you're running a private repository in a non-GitHub Enterprise account, you will get the following installation error, and **won't be able to use this scaffold today**.
+```console
+✘ Creation of pr, dev, staging, and prod code repository environments failed with the following message: Not Found
+```
+:::
 
 :::caution
 Upon running this scaffold, note that you will need to paste your GitHub account's personal access token. You can choose to use an existing one, or even better, create a new one simply by clicking on the [following link](https://github.com/settings/tokens/new?scopes=repo,workflow&description=webiny-cicd-token).

--- a/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
+++ b/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
@@ -14,6 +14,12 @@ import ghActions from "./ci-cd/gh_actions_logo.png";
 
 This feature is available since **v5.7.0**.
 
+You're using a **public repo** or a **private repo under a GitHub Enterprise** account.  
+The current GitHub CI/CD set up relies on [GitHub Environments](https://docs.github.com/en/actions/reference/environments). Environments are only available in public repositories - for all GitHub products - or private repositories in GitHub Enterprise.
+If you're running a private repository in a non-GitHub Enterprise account, you will get the following installation error, and **won't be able to use this scaffold today**.
+```console
+✘ Creation of pr, dev, staging, and prod code repository environments failed with the following message: Not Found
+```
 :::
 
 :::tip What you'll learn

--- a/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
+++ b/docs/how-to-guides/webiny-cli/scaffolding/ci-cd.mdx
@@ -69,6 +69,13 @@ The created workflow files follow workflows described in the [CI/CD](/docs/key-t
 
 :::info
 Workflows rely on [GitHub Environments](https://docs.github.com/en/actions/reference/environments) in order to establish environment protection rules and store all of the necessary secrets, for example AWS credentials or [Pulumi Backend](/docs/key-topics/ci-cd/cloud-infrastructure-state-files#using-different-backends).
+
+[GitHub Environments](https://docs.github.com/en/actions/reference/environments) are only available in public repositories - for all GitHub products - or private repositories in GitHub Enterprise.
+If you're running a private repository in a non-GitHub Enterprise account, you will get the following installation error:
+```console
+✘ Creation of pr, dev, staging, and prod code repository environments failed with the following message: Not Found
+```
+Without Environments set up the system will use the same credentials to deploy to all environments.
 :::
 
 #### Next Steps


### PR DESCRIPTION
## Short Description
The current CI/CD scaffold for GH relies on GH Environments. Environments are not supported by private repos, unless these are under a GH Ent account. This PR adds messaging to the scaffold docs with the types of repos supported by the scaffold.

## Relevant Links
https://deploy-preview-328--webiny-docs.netlify.app/docs/how-to-guides/webiny-cli/scaffolding/ci-cd/

## Checklist
- [ ] I added page metadata (description, keywords)
- [X] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [X] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 