### PR TITLE
docs: added additional steps and examples to creating custom models - basic example section

### DIFF
--- a/docs/how-to-guides/webiny-applications/headless-cms/content-model-plugins.mdx
+++ b/docs/how-to-guides/webiny-applications/headless-cms/content-model-plugins.mdx
@@ -113,11 +113,33 @@ export default [
 ];
 ```
 
-:::info
-Do note that you will also need to import the newly created [`api/code/headlessCMS/src/plugins/models.ts`](https://github.com/webiny/webiny-examples/blob/master/headless-cms/content-model-plugins/basic/api/code/headlessCMS/src/plugins/models.ts) file and register the created plugins in the [`api/code/headlessCMS/src/index.ts`](https://github.com/webiny/webiny-examples/blob/master/headless-cms/content-model-plugins/basic/api/code/headlessCMS/src/index.ts#L42) entrypoint file.
-:::
+Now head to [`api/code/headlessCMS/src/index.ts`](https://github.com/webiny/webiny-examples/blob/master/headless-cms/content-model-plugins/basic/api/code/headlessCMS/src/index.ts#L42) and register the new plugins.
 
-Once registered, we should end up with the following two items in our Admin Area main menu:
+```ts title="api/code/headlessCMS/src/index.ts"
+...
+
+// Importing custom plugins
+import customModels from "./plugins/models"
+
+...
+
+export const handler = createHandler({
+    plugins: [
+        ...
+        customModels
+    ],
+    http: { debug }
+});
+
+```
+
+Finally don't forget to redeploy the headlessCMS app, by running (change then ``env`` value accordingly):
+
+```console 
+yarn webiny deploy api/headlessCMS --env dev
+```
+
+Once registered and deployed, we should end up with the following two items in our Admin Area main menu:
 
 <CenteredImage
   alt="Product and E-Commerce Items in the Admin Area Main Menu"


### PR DESCRIPTION
## Short Description
Added additional steps and examples to creating custom models - basic example section. New steps and code examples include: 1. how to register the plugins, 2. step to redeploy the hCMS app.

## Relevant Links


## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [X] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

## Screenshots (if relevant):
New section

<img width="849" alt="image" src="https://user-images.githubusercontent.com/8825508/129329034-87edf991-99fc-42a5-8e1c-02e923e5c655.png">

