### PR TITLE
fix: output command, added missing folder parameter

### DIFF
--- a/docs/key-topics/webiny-cli.mdx
+++ b/docs/key-topics/webiny-cli.mdx
@@ -55,7 +55,7 @@ The `--env` argument is required.
 For more hands-on information on the above listed commands, please visit the [Deploy Your Project](/docs/how-to-guides/deployment/deploy-your-project) and [Destroy Cloud Infrastructure](/docs/how-to-guides/deployment/destroy-cloud-infrastructure) guides.
 :::
 
-### `yarn webiny output --env {env}`
+### `yarn webiny output {folder} --env {env}`
 
 Returns stack output for the specified project application and environment.
 


### PR DESCRIPTION
Thanks @Pavel910 for reporting and fix.

## Short Description
`folder` parameter was missing in the `output` command doc.
Added missing folder parameter.
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- Preview: https://deploy-preview-344--webiny-docs.netlify.app/docs/key-topics/webiny-cli/#yarn-webiny-output---env-env

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

The rest Checklist is not applicable.

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
