### PR TITLE
fix: separated code blocks for the React plugin example

### DIFF
--- a/docs/key-topics/plugins.mdx
+++ b/docs/key-topics/plugins.mdx
@@ -67,7 +67,7 @@ This is the whole concept. Keep in mind that you will never need to create your 
 
 The `@webiny/plugins` package always exports one ready-made instance of the `PluginsContainer`, so you never need to create it yourself. Think of it as a globally accessible singleton. We need a singleton to import plugins from other `npm` packages, and by having them all import this same package (`@webiny/plugins`), at _build time_, they will be referencing the same webpack module. This means that at _runtime_, all the external plugins will be working with this one centralized registry, and will be able to access all of your app's plugins.
 
-```ts title="Working With Plugins in React"
+```ts title="Working With Plugins in React - Register plugin"
 // Import the global plugins container.
 import { plugins } from "@webiny/plugins";
 
@@ -78,7 +78,9 @@ plugins.register({
     alert("Hello, adventurer!");
   }
 });
+```
 
+```ts title="Working With Plugins in React - Invoke plugin"
 // Use plugins anywhere in your application (even in 3rd party npm packages).
 import { plugins } from "@webiny/plugins";
 


### PR DESCRIPTION
## Short Description
Separated code block example under the React Plugin section into 2 code blocks, one for plugin registration and another for plugin invocation.

## Relevant Links


## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [X] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
<img width="750" alt="image" src="https://user-images.githubusercontent.com/8825508/140375234-77ee81a6-6447-489c-afcc-320514618f2b.png">

