### PR TITLE
fix(upgrade-guide): patch for the 5.17.0

### DIFF
--- a/docs/release-notes/5.17.0/upgrade-guide.mdx
+++ b/docs/release-notes/5.17.0/upgrade-guide.mdx
@@ -54,11 +54,21 @@ yarn webiny upgrade
 
 The upgrade script will make a couple of changes to your existing **API** project application's code (located within the `api` folder) and several changes to your **Admin Area** project application. Once the upgrade command has finished, you can run the [`git status`](https://git-scm.com/docs/git-status) command to see all changes that the command performed.
 
+## 4. Patch the Migration
+After testing the upgrade with several of our clients, we discovered various edge cases that were not originally handled by the migration script. Those edge cases originated from the earlier Webiny versions, prior to 5.16. To make the upgrade script more robust, you need to run the following gist, before deploying your project:
+```bash
+npx https://gist.github.com/Pavel910/fa8f1a4d0bd0296665251897f0f54506
+```
+
+```info
+If you’re deploying your project from a CI/CD pipeline, make sure you add this command before your deploy step.
+```
+
 ---
 
 Before moving on to the next step, review the changes in your IDE, and remove the backup files created by the upgrade script.
 
-## 4. Deploy Your Project
+## 5. Deploy Your Project
 
 Finally, proceed by re-deploying your Webiny project:
 

--- a/docs/release-notes/5.17.0/upgrade-guide.mdx
+++ b/docs/release-notes/5.17.0/upgrade-guide.mdx
@@ -60,9 +60,9 @@ After testing the upgrade with several of our clients, we discovered various edg
 npx https://gist.github.com/Pavel910/fa8f1a4d0bd0296665251897f0f54506
 ```
 
-```info
+:::info
 If you’re deploying your project from a CI/CD pipeline, make sure you add this command before your deploy step.
-```
+:::
 
 ---
 


### PR DESCRIPTION
## Short Description
Add patch note for the 5.17.0 upgrade guide

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [Added patch notes](https://deploy-preview-352--webiny-docs.netlify.app/docs/release-notes/5.17.0/upgrade-guide/#4-patch-the-migration)