### PR TITLE
Fix tip box

### DIFF
--- a/docs/how-to-guides/deployment/aws/credentials.mdx
+++ b/docs/how-to-guides/deployment/aws/credentials.mdx
@@ -10,7 +10,7 @@ description: Configure AWS credentials.
 
 - how to configure your AWS credentials for programmatic access
 - how to create a user with fine-grained policies using CloudFormation template
-  :::
+:::
 
 import YouTube from "@components/Youtube";
 


### PR DESCRIPTION
## Short Description
Fixes the tip box at the start, see screenshot below.

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [Configure AWS Credentials](https://www.webiny.com/docs/how-to-guides/deployment/aws/configure-aws-credentials/)
- [Preview](https://deploy-preview-358--webiny-docs.netlify.app/docs/how-to-guides/deployment/aws/configure-aws-credentials)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
<img width="844" alt="Bildschirmfoto 2021-11-25 um 08 20 10" src="https://user-images.githubusercontent.com/82714642/143396973-4c330176-7ce7-46fb-bc12-f6d8f69e7b0d.png">

