### PR TITLE
docs: renamed Webiny Applications menu to Serverless CMS & added the extend GraphQL API guide to menu

### DIFF
--- a/docs/webiny-overview/serverless-cms/apps/intro.mdx
+++ b/docs/webiny-overview/serverless-cms/apps/intro.mdx
@@ -1,7 +1,7 @@
 ---
 id: intro
 title: Serverless CMS
-sidebar_label: Serverless CMS
+sidebar_label: Introduction
 keywords: ["serverless", "cms", "headless cms", "graphql"]
 description: Webiny Serverless CMS Intro
 ---

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -258,6 +258,7 @@ module.exports = {
                 },
                 "how-to-guides/environment-variables",
                 "how-to-guides/importing-plugins",
+                "how-to-guides/extend-graphql-api",
                 {
                     type: "category",
                     label: "UI Composer",

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -75,7 +75,7 @@ module.exports = {
         },
         {
             type: "category",
-            label: "Webiny Applications",
+            label: "Serverless CMS",
             items: [
                 "webiny-overview/serverless-cms/apps/intro",
                 {


### PR DESCRIPTION
Thanks: Adrian & Pedro for the inputs.

## Short Description
Renamed Webiny Applications menu to Serverless CMS. 
Also added the extend GraphQL API guide to the menu again.

I removed it while [menu restructuring](https://github.com/webiny/docs.webiny.com/pull/347); I was not sure that this would be relevant after our new scaffold. I discussed this with @doitadrian, and we concluded it is still relevant and gives way to users who manually want to extend GraphQL API with lesser code.  

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
https://deploy-preview-362--webiny-docs.netlify.app/docs

## Checklist
N/A
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 


<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
