### PR TITLE
fix(key-topics): headless cms lifecycle events

### DIFF
--- a/docs/key-topics/headless-cms/lifecycle-events.mdx
+++ b/docs/key-topics/headless-cms/lifecycle-events.mdx
@@ -87,6 +87,7 @@ const notifyDifferentSystemWhenEntryIsCreated = new ContextPlugin<CmsContext>(as
     if (!context.cms) {
         return;
     }
+
     context.cms.onAfterEntryCreate.subscribe(async params => {
         const {
             /**


### PR DESCRIPTION
## Short Description
Add a check before attaching cms event