### PR TITLE
fix: 'Edit this page' option in footer was broken, corrected the editUrl to fix it

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,7 @@ const siteConfig = {
                 docs: {
                     path: "./docs",
                     sidebarPath: require.resolve("./sidebars.js"),
-                    editUrl: "https://github.com/webiny/docs.webiny.com/edit/master/docs/",
+                    editUrl: "https://github.com/webiny/docs.webiny.com/edit/master/",
                     showLastUpdateAuthor: true,
                     showLastUpdateTime: true
                 },


### PR DESCRIPTION
## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->
The 'Edit this page' option is footer was broken because it was forming the incorrect URL i.e. having `/docs/` twice in URL, fixed it by updating the `editUrl` property in  docusaurus config.

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
https://deploy-preview-388--webiny-docs.netlify.app/docs/webiny/introduction/


## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

Rest are not applicable. 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
![Edit this page](https://user-images.githubusercontent.com/7145848/152146812-d80d4a4b-5f2d-4793-a627-fd821782882c.png)
