### PR TITLE
Request to update 'webiny output' command link

### DIFF
--- a/docs/tutorials/create-custom-application/graphql-api.mdx
+++ b/docs/tutorials/create-custom-application/graphql-api.mdx
@@ -112,7 +112,7 @@ For more information on how to use it, revisit the [Using the Watch Command](/do
 
 ### Retrieving the GraphQL API URL
 
-Before we continue, note that in order to do a quick manual test of our GraphQL API, we need to have the URL over which it can be accessed. This is where the following [`webiny output`](/docs/key-topics/webiny-cli#yarn-webiny-output---env-env) command can help us:
+Before we continue, note that in order to do a quick manual test of our GraphQL API, we need to have the URL over which it can be accessed. This is where the following [`webiny output`](https://www.webiny.com/docs/key-topics/webiny-cli/#yarn-webiny-output-folder---env-env) command can help us:
 
 ```bash
 yarn webiny output pinterest-clone/api --env dev

--- a/docs/tutorials/create-custom-application/graphql-api.mdx
+++ b/docs/tutorials/create-custom-application/graphql-api.mdx
@@ -112,7 +112,7 @@ For more information on how to use it, revisit the [Using the Watch Command](/do
 
 ### Retrieving the GraphQL API URL
 
-Before we continue, note that in order to do a quick manual test of our GraphQL API, we need to have the URL over which it can be accessed. This is where the following [`webiny output`](https://www.webiny.com/docs/key-topics/webiny-cli/#yarn-webiny-output-folder---env-env) command can help us:
+Before we continue, note that in order to do a quick manual test of our GraphQL API, we need to have the URL over which it can be accessed. This is where the following [`webiny output`](/docs/key-topics/webiny-cli/#yarn-webiny-output-folder---env-env) command can help us:
 
 ```bash
 yarn webiny output pinterest-clone/api --env dev


### PR DESCRIPTION
Page: https://www.webiny.com/docs/tutorials/create-custom-application/graphql-api

- In the 'Retrieving the GraphQL API URL' section, the 'webiny output' link leads to the correct page but displays the wrong (yarn webiny disable-telemetry) command. I updated to the correct link that leads to the 'webiny output' command. I request you to accept the update, if you agree.

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
