### PR TITLE
Request to update 'PbEditorPageElementPlugin' link

### DIFF
--- a/docs/tutorials/page-builder/create-a-new-page-element.mdx
+++ b/docs/tutorials/page-builder/create-a-new-page-element.mdx
@@ -405,7 +405,7 @@ As mentioned, this code will show the settings UI in sidebar and ask for the URL
 
 As mentioned, every page element consists of two sets of plugins. We've already covered the editor side of the logic, now, let's write the plugin that will render it to the page preview and the actual page.
 
-In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](/docs/references/page-builder/plugins#pb-editor-page-element) plugin. 
+In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](/docs/references/page-builder/plugins#pb-editor-page-element) plugin.
 Create [`index.tsx`](https://github.com/webiny/webiny-examples/blob/master/iframe-page-element/apps/extensions/pb-element-iframe/render/index.tsx) file in the `apps/extensions/pb-element-iframe/render` directory.
 
 ```tsx title="apps/extensions/pb-element-iframe/render/index.tsx"

--- a/docs/tutorials/page-builder/create-a-new-page-element.mdx
+++ b/docs/tutorials/page-builder/create-a-new-page-element.mdx
@@ -405,7 +405,7 @@ As mentioned, this code will show the settings UI in sidebar and ask for the URL
 
 As mentioned, every page element consists of two sets of plugins. We've already covered the editor side of the logic, now, let's write the plugin that will render it to the page preview and the actual page.
 
-In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](https://www.webiny.com/docs/references/page-builder/plugins#pb-editor-page-element) plugin. 
+In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](/docs/references/page-builder/plugins#pb-editor-page-element) plugin. 
 Create [`index.tsx`](https://github.com/webiny/webiny-examples/blob/master/iframe-page-element/apps/extensions/pb-element-iframe/render/index.tsx) file in the `apps/extensions/pb-element-iframe/render` directory.
 
 ```tsx title="apps/extensions/pb-element-iframe/render/index.tsx"

--- a/docs/tutorials/page-builder/create-a-new-page-element.mdx
+++ b/docs/tutorials/page-builder/create-a-new-page-element.mdx
@@ -405,7 +405,7 @@ As mentioned, this code will show the settings UI in sidebar and ask for the URL
 
 As mentioned, every page element consists of two sets of plugins. We've already covered the editor side of the logic, now, let's write the plugin that will render it to the page preview and the actual page.
 
-In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](/docs/references/page-builder/plugins#pb-editor-page-element) plugin.
+In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](/docs/references/page-builder/plugins#pb-editor-page-element) plugin.  
 Create [`index.tsx`](https://github.com/webiny/webiny-examples/blob/master/iframe-page-element/apps/extensions/pb-element-iframe/render/index.tsx) file in the `apps/extensions/pb-element-iframe/render` directory.
 
 ```tsx title="apps/extensions/pb-element-iframe/render/index.tsx"

--- a/docs/tutorials/page-builder/create-a-new-page-element.mdx
+++ b/docs/tutorials/page-builder/create-a-new-page-element.mdx
@@ -405,7 +405,7 @@ As mentioned, this code will show the settings UI in sidebar and ask for the URL
 
 As mentioned, every page element consists of two sets of plugins. We've already covered the editor side of the logic, now, let's write the plugin that will render it to the page preview and the actual page.
 
-In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](/docs/references/page-builder/plugins#pb-render-page-element) plugin.  
+In order to render the element on the actual page, we will use the [`PbEditorPageElementPlugin`](https://www.webiny.com/docs/references/page-builder/plugins#pb-editor-page-element) plugin. 
 Create [`index.tsx`](https://github.com/webiny/webiny-examples/blob/master/iframe-page-element/apps/extensions/pb-element-iframe/render/index.tsx) file in the `apps/extensions/pb-element-iframe/render` directory.
 
 ```tsx title="apps/extensions/pb-element-iframe/render/index.tsx"


### PR DESCRIPTION
Page: https://www.webiny.com/docs/tutorials/page-builder/create-a-new-page-element/

- In the 'Render Element Plugin' section, 'PbEditorPageElementPlugin' links to the 'pb-render-page-element' section instead of 'pb-editor-page-element'. I have updated the link. If you agree, please accept the update.

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
