### PR TITLE
The npm page, @webiny-contrib, is blank

### DIFF
--- a/docs/community-plugins/introduction.mdx
+++ b/docs/community-plugins/introduction.mdx
@@ -68,7 +68,7 @@ Please place your code under the `src` directory e.g. `plugins/pageBuilder/ifram
 ### 4. Raise the Pull Request
 
 Once the plugin is ready, please create a pull request to [https://github.com/webiny-contrib/plugins](https://github.com/webiny-contrib/plugins) repository.
-Webiny team will take care of publishing the community plugins to `npm` at [@webiny-contrib](https://www.npmjs.com/package/@webiny-contrib/).
+Webiny team will take care of publishing the community plugins to `npm` at [@webiny-contrib](https://www.npmjs.com/package/@webiny-contrib/). 
 
 ## Contribute to Existing Plugins
 


### PR DESCRIPTION
Page: https://www.webiny.com/docs/community-plugins/introduction

- In Step 4, 'Raise the Pull Request', the '@webiny-contrib' link leads to a page (https://www.npmjs.com/package/@webiny-contrib) with no entries. I assume this will be active when new community plugins are added? If so, please ignore this comment, and I will close this PR. If the link has to be updated, please provide the correct link, and I will update it.

## Short Description
<!--- Shortly describe what this PR introduces. -->
<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
