### PR TITLE
docs: updated code references customize existing page element as per the new pattern

### DIFF
--- a/src/pages/docs/page-builder/extending/customize-an-existing-element.mdx
+++ b/src/pages/docs/page-builder/extending/customize-an-existing-element.mdx
@@ -41,13 +41,15 @@ All element plugins are registered as a factory so you can customize them by pas
 ```ts @webiny/app-page-builder/types
 type PbEditorElementPluginArgs = {
   // A function to create an element data structure.
-  create?: (defaultValue) => Record<string, any>
+  create?: (defaultValue: Partial<PbEditorElement>) => PbEditorElement;
   // Array of element settings plugin names.
-  settings?: (defaultValue) => Array<string | Array<string | any>>
+  settings?: (
+      defaultValue: PbEditorPageElementPluginSettings
+  ) => Array<string | Array<string | any>>;
   // A function that return the toolbar properties of the element plugin.
-  toolbar?: (defaultValue) => Record<string, any>
-  elementType?: string
-}
+  toolbar?: (defaultValue: PbEditorPageElementPluginToolbar) => React.ReactNode;
+  elementType?: string;
+};
 ```
 
 ## Add Settings in an Element
@@ -82,8 +84,8 @@ Let's make the following change.
 export default [
   ...
   button({
-    settings: defaultValue => [
-      ...defaultValue,
+    settings: (defaultValue?: string[]) => [
+      ...(Array.isArray(defaultValue) ? defaultValue : []),
       "pb-editor-page-element-style-settings-padding",
       "pb-editor-page-element-style-settings-width"
     ]


### PR DESCRIPTION
## Short Description
Updated some obsolete code patterns of customizing existing page element.

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->

## Checklist
- [x] I added page metadata (description, keywords)
- [x] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [x] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [x] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [x] I added `alt` / `title` attributes for inserted images (if any)
- [x] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
