### PR TITLE
fix(nextjs): update rich text module import instructions

### DIFF
--- a/src/pages/docs/headless-cms/integrations/nextjs.mdx
+++ b/src/pages/docs/headless-cms/integrations/nextjs.mdx
@@ -275,15 +275,17 @@ You should now be able to see your data! Run `yarn dev` and open the browser on 
 
 You may have noticed that we chose a `rich-text` field for the **body** of the post. To render this in React, you can use [our rich text renderer package](https://www.npmjs.com/package/@webiny/react-rich-text-renderer):
 
+This package will work with v5.25.0 of Webiny, but for now it's available with the beta release, so you can install it from the beta:
+
 ```bash
-npm install @webiny/react-rich-text-renderer
+npm install @webiny/react-rich-text-renderer@beta
 ```
 
 Once the package is installed, you can use it as you would any other component:
 
 ```jsx /pages/posts/[slug].js
 // import the renderer
-import { RichTextRenderer }
+import { RichTextRenderer } from '@webiny/react-rich-text-renderer'
 
 // in your render function
 <RichTextRenderer data={content} />


### PR DESCRIPTION
Docs page has incorrect import instructions for the beta release of v5.25.0, this update that and another syntactical error.