### PR TITLE
fix(navs): put back headless cms integrations links

### DIFF
--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -39,6 +39,10 @@ export const documentationNav = [
             page("headless-cms/extending/extend-graphql-api"),
             page("headless-cms/extending/render-rich-text-content"),
         ]),
+        section('Integrations', [
+          page('headless-cms/integrations/nextjs'),
+          page('headless-cms/integrations/gatsby'),
+        ]),
         section("References", [
             page("headless-cms/references/lifecycle-events"),
             page("headless-cms/references/plugins"),


### PR DESCRIPTION
## Short Description
Put back links to headless CMS integrations in nav menu (pages were still there)