### PR TITLE
docs: fixed the typo in making a text bold

### DIFF
--- a/src/pages/docs/overview/introduction.mdx
+++ b/src/pages/docs/overview/introduction.mdx
@@ -14,7 +14,7 @@ import { Alert } from "@/components/Alert"
 
 Welcome! 👋
 
-***Webiny**** is an open-source content management system designed for enterprises. It's built on top of the serverless infrastructure to enable great scalability and site reliability even in the most demanding periods.
+Webiny is an open-source content management system designed for enterprises. It's built on top of the serverless infrastructure to enable great scalability and site reliability even in the most demanding periods.
 
 Webiny stands out from the crowd with its unique feature set, architecture, and open-source community. In the following few sections, you'll get to know Webiny, what it can do, and how to best use it to its full advantage.
 


### PR DESCRIPTION
## Short Description
It seems during refactoring an extra `*` were left in Webiny word. Removed it and made it a normal word. 

![typo](https://user-images.githubusercontent.com/7145848/167238755-136de949-43ab-4c63-b39b-a5eeff28ed25.png)

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
-

## Checklist
- [x] I added page metadata (description, keywords)
- [x] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [x] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [x] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [x] I added `alt` / `title` attributes for inserted images (if any)
- [x] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
