### PR TITLE
feat: upgrade notes for 5.25.0

### DIFF
--- a/src/pages/docs/release-notes/5.25.0/upgrade-guide.mdx
+++ b/src/pages/docs/release-notes/5.25.0/upgrade-guide.mdx
@@ -27,7 +27,21 @@ yarn up "@webiny/*@5.25.0"
 
 Once the upgrade has finished, running the `yarn webiny --version` command in your terminal should return `5.25.0`.
 
-## 2. Deploy Your Project
+<Alert type="info">
+
+Before moving on, make sure you commit all your changes.
+
+</Alert>
+
+## 2. Run the Upgrade Command
+
+The next step is to run the project upgrade:
+
+```bash
+yarn webiny upgrade
+```
+
+## 3. Deploy Your Project
 
 Proceed by re-deploying your Webiny project:
 


### PR DESCRIPTION
## Short Description
Added missing 5.25.0 upgrade project notes.

## Relevant Links
- [Upgrade command](https://docs-webiny-com-git-feat-upgrade-5250-webiny.vercel.app/docs/release-notes/5.25.0/upgrade-guide#2-run-the-upgrade-command)
