### PR TITLE
docs: fixed the broken link for prod/index.ts file

### DIFF
--- a/src/pages/docs/infrastructure/basics/destroy-cloud-infrastructure.mdx
+++ b/src/pages/docs/infrastructure/basics/destroy-cloud-infrastructure.mdx
@@ -75,7 +75,7 @@ Within a Webiny project, note that the `pulumi up` and `pulumi destroy` commands
 
 </Alert>
 
-So, in order to destroy all cloud infrastructure resources deployed into the `prod` environment, for starters, unmark all cloud resources as protected, which can be done by setting the `protectedEnvironment` [(`api/pulumi/prod/index.ts`)](https://github.com/webiny/webiny-js/blob/617751651e1f95338391805a458cb79b17f81678/packages/cwp-template-aws/template/ddb/api/pulumi/prod/index.ts#L22) flag to `false`.
+So, in order to destroy all cloud infrastructure resources deployed into the `prod` environment, for starters, unmark all cloud resources as protected, which can be done by setting the `protectedEnvironment` [(`api/pulumi/prod/index.ts`)](https://github.com/webiny/webiny-js/blob/v5.27.0/packages/cwp-template-aws/template/ddb/api/pulumi/prod/index.ts#L22) flag to `false`.
 
 Once that's in place, run the [`webiny deploy`](../../core-development-concepts/basics/project-deployment) command to apply changes, and finally, run the [`webiny destroy`](../../infrastructure/basics/destroy-cloud-infrastructure) to destroy everything.
 

--- a/src/pages/docs/infrastructure/basics/destroy-cloud-infrastructure.mdx
+++ b/src/pages/docs/infrastructure/basics/destroy-cloud-infrastructure.mdx
@@ -75,7 +75,7 @@ Within a Webiny project, note that the `pulumi up` and `pulumi destroy` commands
 
 </Alert>
 
-So, in order to destroy all cloud infrastructure resources deployed into the `prod` environment, for starters, unmark all cloud resources as protected, which can be done by setting the `protectedEnvironment` [(`api/pulumi/prod/index.ts`)](https://github.com/webiny/webiny-js/blob/next/packages/cwp-template-aws/template/api/pulumi/prod/index.ts#L17) flag to `false`.
+So, in order to destroy all cloud infrastructure resources deployed into the `prod` environment, for starters, unmark all cloud resources as protected, which can be done by setting the `protectedEnvironment` [(`api/pulumi/prod/index.ts`)](https://github.com/webiny/webiny-js/blob/617751651e1f95338391805a458cb79b17f81678/packages/cwp-template-aws/template/ddb/api/pulumi/prod/index.ts#L22) flag to `false`.
 
 Once that's in place, run the [`webiny deploy`](../../core-development-concepts/basics/project-deployment) command to apply changes, and finally, run the [`webiny destroy`](../../infrastructure/basics/destroy-cloud-infrastructure) to destroy everything.
 


### PR DESCRIPTION
## Short Description
Fixed the broken link for `prod/index.ts` file

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->

## Checklist
- [x] I added page metadata (description, keywords)
- [x] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [x] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [x] I used title case for titles and subtitles (in the main menu and in the page content)
- [x] I checked for typos and grammar mistakes
- [x] I added `alt` / `title` attributes for inserted images (if any)
- [x] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
