### PR TITLE
Destroy Command Docs - Fix Order of Execution

### DIFF
--- a/src/docs/5.29.x/infrastructure/basics/destroy-cloud-infrastructure.mdx
+++ b/src/docs/5.29.x/infrastructure/basics/destroy-cloud-infrastructure.mdx
@@ -52,7 +52,7 @@ yarn webiny destroy apps/api --env dev
 yarn webiny destroy apps/core --env dev
 ```
 
-Note that the order of execution matters. In order to correctly and fully destroy your Webiny project's cloud infrastructure resources, the above commands should be executed in this exact order.
+Note that the order of execution matters. In order to correctly and fully destroy your Webiny project's cloud infrastructure resources, the above commands should be executed in that exact order.
 
 ## Debugging
 

--- a/src/docs/5.29.x/infrastructure/basics/destroy-cloud-infrastructure.mdx
+++ b/src/docs/5.29.x/infrastructure/basics/destroy-cloud-infrastructure.mdx
@@ -46,11 +46,13 @@ As its first argument, the `destroy` command receives the path to the project ap
 The following destroy commands destroy cloud infrastructure deployed for four project applications, all previously deployed into the `dev` environment:
 
 ```bash
-yarn webiny destroy apps/core --env dev
-yarn webiny destroy apps/api --env dev
-yarn webiny destroy apps/admin --env dev
 yarn webiny destroy apps/website --env dev
+yarn webiny destroy apps/admin --env dev
+yarn webiny destroy apps/api --env dev
+yarn webiny destroy apps/core --env dev
 ```
+
+Note that the order of execution matters. In order to correctly and fully destroy your Webiny project's cloud infrastructure resources, the above commands should be executed in this exact order.
 
 ## Debugging
 
@@ -87,6 +89,7 @@ export default createCoreApp({
 ```
 
 Once that's in place, run the [`webiny deploy`](../../core-development-concepts/basics/project-deployment) command to apply changes, and finally, run the [`webiny destroy`](../../infrastructure/basics/destroy-cloud-infrastructure) to destroy everything:
+
 
 ```bash
 # Removes the protection from mission-critical cloud infrastructure resources.


### PR DESCRIPTION
## Short Description
This PR fixes the destroy command page - corrects the order of `destroy` command execution.

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [A change on X page](#)
- [Update list of libraries](#)
- [A new diagram with updated resources](#)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
