### PR TITLE
fix(headless-cms): content models via code immutable definitions

### DIFF
--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -378,8 +378,7 @@ Here are a couple of examples of specifying icons from solid, regular, and brand
 
 ## Immutable Code Definitions
 
-As you can do what ever you want with the models via code, there are things you need to be really careful about.
-We cannot prevent you to change anything, so you need to be watchful when creating models via code.
+You can do what ever you want with the models via code. For that reason, there are things you need to be really careful about. We cannot prevent you from changing anything, so you need to be watchful for these pitfalls.
 
 You should **never** change `modelId` property of the model definition.
 

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -385,15 +385,15 @@ You should **never** change `modelId` property of the model definition.
 
 There are also few field properties which must **never** change, if you want to keep your data.
 
-Fields are:
+Properties are:
  - `id`
  - `storageId` - if you have created it manually
  - `type`
  - `multipleValues`
  - `predefinedValues` - you can add values but do not remove them
 
-Also, you have defined some settings:
+Also, you have defined anything settings, be careful about these properties:
 
  - `settings.fields` - same rule applies as for the parent field
- - `settings.models` - you can add models but do not remove them - you will lose data
+ - `settings.models` - you can add models but do not remove them
  - `settings.type`

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -375,3 +375,25 @@ Here are a couple of examples of specifying icons from solid, regular, and brand
 - `far/copy`
 - `fab/aws`.
 - `fab/react`.
+
+## Immutable Code Definitions
+
+As you can do what ever you want with the models via code, there are things you need to be really careful about.
+We cannot prevent you to change anything, so you need to be watchful when creating models via code.
+
+You should **never** change `modelId` property of the model definition.
+
+There are also few field properties which must **never** change, if you want to keep your data.
+
+Fields are:
+ - `id`
+ - `storageId` - if you have created it manually
+ - `type`
+ - `multipleValues`
+ - `predefinedValues` - you can add values but do not remove them
+
+Also, you have defined some settings:
+
+ - `settings.fields` - same rule applies as for the parent field
+ - `settings.models` - you can add models but do not remove them - you will lose data
+ - `settings.type`

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -391,7 +391,7 @@ Properties are:
  - `multipleValues`
  - `predefinedValues` - you can add values but do not remove them
 
-Also, you have defined anything settings, be careful about these properties:
+Also, if you have defined anything settings, be careful about these properties:
 
  - `settings.fields` - same rule applies as for the parent field
  - `settings.models` - you can add models but do not remove them

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -391,8 +391,8 @@ Properties are:
  - `multipleValues`
  - `predefinedValues` - you can add values but do not remove them
 
-Also, if you have defined anything settings, be careful about these properties:
+Also, if you have defined anything in `settings` property of the field, be careful about these properties:
 
- - `settings.fields` - same rule applies as for the parent field
+ - `settings.fields` - same rules apply as for the parent field
  - `settings.models` - you can add models but do not remove them
  - `settings.type`


### PR DESCRIPTION
## Short Description
Warning about changing model via code definitions.

## Relevant Links
<!--- If possible, please include the URLs of the newly added or edited pages (wait for the Netlify preview to be deployed and then paste the links). -->
- [Immutable Code Definitions in Model](https://docs-webiny-ck0iavwaw-webiny.vercel.app/docs/headless-cms/extending/content-models-via-code#immutable-code-definitions)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
