### PR TITLE
fix: Added ts-ignore hint to the okta-sign-in widget import

### DIFF
--- a/src/docs/5.29.x/enterprise/okta-integration.mdx
+++ b/src/docs/5.29.x/enterprise/okta-integration.mdx
@@ -315,6 +315,7 @@ Copy the following code, and place it in `apps/admin/src/okta.ts`:
 
 ```tsx apps/admin/src/okta.ts
 import { OktaFactory } from "@webiny/app-admin-okta";
+// @ts-ignore
 import OktaSignIn from "@okta/okta-signin-widget";
 import { OktaAuth } from "@okta/okta-auth-js";
 import "@okta/okta-signin-widget/dist/css/okta-sign-in.min.css";


### PR DESCRIPTION
## Short Description
Build failing when Okta plugin is configured.
Added ts-ignore hint to the okta-sign-in widget import, since Okta doesn't support types and we recently introduced strict-mode.

## Relevant Links
https://docs-webiny-com-git-fix-okta-webiny.vercel.app/docs/enterprise/okta-integration

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
