### PR TITLE
feat: adding custom routes

### DIFF
--- a/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
+++ b/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
@@ -1,6 +1,6 @@
 ---
-title: Adding Custom Route to Existing Lambda
-description: Learn how to add a custom route to our existing Lambda
+title: Adding Custom Route to Existing Webiny Lambda
+description: Learn how to add a custom route to existing Webiny Lambda
 ---
 
 import { Alert } from "@/components/Alert";
@@ -48,9 +48,9 @@ export default createApiApp({
 
 After these changes, feel free to deploy the api part of your project to test if new route is working. Use your favorite HTTP client to test it out.
 
-## Adding a Route to the GraphQL Handler
+## Adding a Route to the Handler
 
-After you added the route to the `API Gateway`, you can move onto creating a route in our existing GraphQL Lambda handler.
+After you added the route to the `API Gateway`, you can move onto creating a route in our existing handler.
 
 ```typescript apps/api/graphql/src/index.ts
 // add the import somewhere at the top of the file or update the existing import from @webiny/handler-aws
@@ -94,3 +94,10 @@ In the `createApiGatewayRoute` method callback, there are multiple properties av
 * `context` - our Webiny internal context with all our applications attached to it
 
 The [`request`](https://www.fastify.io/docs/latest/Reference/Request/) and [`reply`](https://www.fastify.io/docs/latest/Reference/Reply/) objects are the original ones from the Fastify, so you can look into their documentation about what they contain and what you can use.
+
+
+<Alert type="info" title="Why only the graphql handler example?">
+
+We will eventually remove the headlessCMS Lambda and its handler, so do not add routes there. Everything you might need from the system is available in the GraphQL Lambda handler.
+
+</Alert>

--- a/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
+++ b/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
@@ -1,0 +1,96 @@
+---
+title: Adding Custom Route to Existing Lambda
+description: Learn how to add a custom route to our existing Lambda
+---
+
+import { Alert } from "@/components/Alert";
+
+<Alert type="success" title="What you'll learn">
+
+- how to add a custom route
+- how to add a custom route handler
+
+</Alert>
+
+## Introduction
+
+Starting with the Webiny version 5.31.0, when we added the [Fastify](https://www.fastify.io/), users can quite easily add new routes to our existing Lambdas.
+
+Users can add as many routes as they want, with possibility for them to be a `POST`, `GET`, `OPTIONS`, `PUT`, `PATH`, `DELETE` and `HEAD` method routes.
+
+## Adding a Route to the API Gateway
+
+First, we need to add the route to the `API Gateway`.
+Without this part, the route will not be known by the `API Gateway` and users will get a `404` response.
+
+```typescript apps/api/webiny.application.ts
+import { createApiApp } from "@webiny/serverless-cms-aws";
+import { ApiGraphql } from "@webiny/pulumi-aws";
+
+export default createApiApp({
+  pulumi: app => {
+    const graphQlModule = app.getModule(ApiGraphql);
+    // add custom POST route
+    graphQlModule.addRoute({
+      name: "my-custom-route-post",
+      path: "/my-custom-path",
+      method: "POST"
+    });
+    // add custom OPTIONS route
+    graphQlModule.addRoute({
+      name: "my-custom-route-options",
+      path: "/my-custom-path",
+      method: "OPTIONS"
+    });
+  }
+});
+```
+
+After these changes, feel free to deploy the api part of your project to test if new route is working. Use your favorite HTTP client to test it out.
+
+## Adding a Route to the GraphQL Handler
+
+After you added the route to the `API Gateway`, you can move onto creating a route in our existing GraphQL Lambda handler.
+
+```typescript apps/api/graphql/src/index.ts
+// add the import somewhere at the top of the file or update the existing import from @webiny/handler-aws
+import { createApiGatewayRoute } from "@webiny/handler-aws";
+
+// existing handler
+export const handler = createHandler({
+    plugins: [
+        // at the end of the plugins array you need to create a new API Gateway route
+        createApiGatewayRoute(({ onPost, onOptions, context }) => {
+          onPost("/my-custom-path", async (request, reply) => {
+              // do something with request
+              if (request.body === null) {
+                  return reply.send({
+                      somethingIsWrong: true
+                  });
+              }
+              return reply.send({
+                  output: true,
+                  someOtherVariable: "xyz"
+              });
+          });
+          onOptions("/my-custom-path", async (_, reply) => {
+              return reply.hijack().send({});
+          });
+      })
+    ]
+});
+```
+
+In the createApiGatewayRoute method callback, there are multiple properties available:
+
+* `onPost` - register a POST method route
+* `onOptions` - register an OPTIONS method route
+* `onDelete` - register a DELETE method route
+* `onPatch` - register a PATCH method route
+* `onGet` - register a GET method route
+* `onHead` - register a HEAD method route
+* `onPut` - register a PUT method route
+* `onAll` - register a route which will catch all the existing methods
+* `context` - our Webiny internal context with all our applications attached to it
+
+The [`request`](https://www.fastify.io/docs/latest/Reference/Request/) and [`reply`](https://www.fastify.io/docs/latest/Reference/Reply/) objects are original ones from the Fastify, so you can look into their documentation about what they contain and what you can use.

--- a/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
+++ b/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
@@ -93,4 +93,4 @@ In the `createApiGatewayRoute` method callback, there are multiple properties av
 * `onAll` - register a route which will catch all the existing methods
 * `context` - our Webiny internal context with all our applications attached to it
 
-The [`request`](https://www.fastify.io/docs/latest/Reference/Request/) and [`reply`](https://www.fastify.io/docs/latest/Reference/Reply/) objects are original ones from the Fastify, so you can look into their documentation about what they contain and what you can use.
+The [`request`](https://www.fastify.io/docs/latest/Reference/Request/) and [`reply`](https://www.fastify.io/docs/latest/Reference/Reply/) objects are the original ones from the Fastify, so you can look into their documentation about what they contain and what you can use.

--- a/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
+++ b/src/docs/5.31.x/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda.mdx
@@ -81,7 +81,7 @@ export const handler = createHandler({
 });
 ```
 
-In the createApiGatewayRoute method callback, there are multiple properties available:
+In the `createApiGatewayRoute` method callback, there are multiple properties available:
 
 * `onPost` - register a POST method route
 * `onOptions` - register an OPTIONS method route

--- a/src/docs/5.31.x/navigation.js
+++ b/src/docs/5.31.x/navigation.js
@@ -12,6 +12,13 @@ export const Navigation = () => {
                 <Section title={"Basics"}>
                     <Page link={"core-development-concepts/basics/routes-and-events"} />
                 </Section>
+                <Section title={"Extending and Customizing"}>
+                    <Page
+                        link={
+                            "core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda"
+                        }
+                    />
+                </Section>
             </Collapsable>
         </>
     );


### PR DESCRIPTION
## Short Description
This PR adds an article on how to add new custom route to our existing Lambda handlers and to the API Gateway - so it is actually passed to the Lambda handler.

## Relevant Links
- [Adding Custom Route to Existing Lambda](https://docs-webiny-com-git-feat-custom-routes-webiny.vercel.app/docs/core-development-concepts/extending-and-customizing/add-custom-route-to-existing-lambda)
