### PR TITLE
docs: migrated information from community Slack to Docs

### DIFF
--- a/src/docs/5.29.x/core-development-concepts/basics/project-deployment.mdx
+++ b/src/docs/5.29.x/core-development-concepts/basics/project-deployment.mdx
@@ -222,3 +222,19 @@ Learn more about cloud infrastructure state files in the [Cloud Infrastructure S
 #### Another Deployment Currently in Progress
 
 In case of the latter, in which an active deployment currently exists, then you'll just need to wait for the first one to finish, and redeploy your project application. Although not that often, this is more possible to happen in your CI/CD workflows.
+
+### Failed to read Pulumi credentials file. Please re-run `pulumi login`.
+When deploying your project applications with the `yarn webiny deploy` command, if you get the following error:
+
+> error: problem logging in: failed to read Pulumi credentials file. Please re-run `pulumi login` to reset your credentials file: invalid character '\x00' looking for beginning of value
+
+This error may be because of the corrupted `credentials.json` file. `credentials.json` is located in the
+`your-webiny-project/.webiny/pulumi-cli/your-operating-system-specific-directory/pulumi/` directory.
+
+Mac / Linux:  
+`/Users/swapnilmmane/my-new-project/.webiny/pulumi-cli/darwin/pulumi/credentials.json`
+
+Windows:  
+`C:\my-new-project\.webiny\pulumi-cli\win32\pulumi\credentials.json`
+
+To fix the error, delete the `credentials.json` file and re-run the deploy command.

--- a/src/docs/5.29.x/core-development-concepts/basics/project-deployment.mdx
+++ b/src/docs/5.29.x/core-development-concepts/basics/project-deployment.mdx
@@ -224,17 +224,25 @@ Learn more about cloud infrastructure state files in the [Cloud Infrastructure S
 In case of the latter, in which an active deployment currently exists, then you'll just need to wait for the first one to finish, and redeploy your project application. Although not that often, this is more possible to happen in your CI/CD workflows.
 
 ### Failed to read Pulumi credentials file. Please re-run `pulumi login`.
-When deploying your project applications with the `yarn webiny deploy` command, if you get the following error:
+
+When deploying your project applications with the [`webiny deploy`](/docs/{version}/core-development-concepts/basics/project-deployment) command, on a couple of occasions, we've seen users receive the following error:
 
 > error: problem logging in: failed to read Pulumi credentials file. Please re-run `pulumi login` to reset your credentials file: invalid character '\x00' looking for beginning of value
 
-This error may be because of the corrupted `credentials.json` file. `credentials.json` is located in the
-`your-webiny-project/.webiny/pulumi-cli/your-operating-system-specific-directory/pulumi/` directory.
+After some investigation, we've seen this error can happen because of an error in the `credentials.json` file, which is an internal Pulumi file that holds [Pulumi service-related](https://www.pulumi.com/docs/intro/pulumi-service/) credentials.
 
-Mac / Linux:  
-`/Users/swapnilmmane/my-new-project/.webiny/pulumi-cli/darwin/pulumi/credentials.json`
+If you're not using Pulumi service, then, most likely, you can safely delete this file, and everything should start working again.
 
-Windows:  
-`C:\my-new-project\.webiny\pulumi-cli\win32\pulumi\credentials.json`
+Depending on your operating system, the file can be found in the following paths.
 
-To fix the error, delete the `credentials.json` file and re-run the deploy command.
+**Mac / Linux:**  
+
+```
+/Users/x/my-new-project/.webiny/pulumi-cli/darwin/pulumi/credentials.json
+```
+
+**Windows:**  
+
+```
+C:\my-new-project\.webiny\pulumi-cli\win32\pulumi\credentials.json
+```

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -340,6 +340,41 @@ As we can see, like in the previous example, we're again utilizing the [`Context
 
 Content models and content model groups that were defined via plugins cannot be edited via Admin Area (via the Content Model Editor and Content Model Groups module). All of the changes need to be done within the application code.
 
+### How to set a default value of a field?
+You can set a default value to a field using the `defaultValue` property. Let's extend the above tutorial and
+set the default value of the `Product Name` attribute.
+
+```ts
+(...)
+fields: [
+  {
+    id: "productName",
+    fieldId: "productName",
+    type: "text",
+    label: "Product Name",
+    helpText: "A short product name",
+    renderer: { name: "text-input" },
+    settings: {
+        defaultValue: "You can set the default name of any product here"
+    }
+    validation: [
+      {
+        name: "required",
+        message: "Value is required."
+      }
+    ]
+  }
+(...)
+```
+
+In short, you will need to add settings -> defaultValue property to define a default value to a field.
+
+```ts
+settings: {
+  defaultValue: "You can set the default name of any product here"
+}
+```
+
 ### Are there any differences when it comes to security controls?
 
 When it comes to security, both ways of defining content models and content model groups have access to the same features and follow the same security-related built-in mechanisms. In other words, via the Security application, you can still decide which users have access to particular content models and content model groups that were defined via plugins, and which don't.

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -344,7 +344,7 @@ Content models and content model groups that were defined via plugins cannot be 
 You can set a default value to a field using the `defaultValue` property. Let's extend the [tutorial above](#create-content-model-group-and-content-model-plugins) and
 set the default value of the `Product Name` attribute.
 
-```ts
+```diff-ts
 (...)
 fields: [
   {
@@ -354,9 +354,9 @@ fields: [
     label: "Product Name",
     helpText: "A short product name",
     renderer: { name: "text-input" },
-    settings: {
-        defaultValue: "You can set the default name of any product here"
-    }
++   settings: {
++       defaultValue: "You can set the default name of any product here"
++   }
     validation: [
       {
         name: "required",
@@ -367,13 +367,7 @@ fields: [
 (...)
 ```
 
-In short, you will need to add settings -> defaultValue property to define a default value to a field.
-
-```ts
-settings: {
-  defaultValue: "You can set the default name of any product here"
-}
-```
+In short, you will need to add `settings.defaultValue` property to define a default value to a field.
 
 ### Are there any differences when it comes to security controls?
 

--- a/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
+++ b/src/docs/5.33.x/headless-cms/extending/content-models-via-code.mdx
@@ -341,7 +341,7 @@ As we can see, like in the previous example, we're again utilizing the [`Context
 Content models and content model groups that were defined via plugins cannot be edited via Admin Area (via the Content Model Editor and Content Model Groups module). All of the changes need to be done within the application code.
 
 ### How to set a default value of a field?
-You can set a default value to a field using the `defaultValue` property. Let's extend the above tutorial and
+You can set a default value to a field using the `defaultValue` property. Let's extend the [tutorial above](#create-content-model-group-and-content-model-plugins) and
 set the default value of the `Product Name` attribute.
 
 ```ts


### PR DESCRIPTION
Please refer to the following new sections that have been added:

- [Failed to Read Pulumi Credentials File. ](https://docs-webiny-com-git-slack-thread-1-webiny.vercel.app/docs/core-development-concepts/basics/project-deployment#failed-to-read-pulumi-credentials-file-please-re-run-pulumi-login) 
- [How to Set a Default Value of a Field?](https://docs-webiny-com-git-slack-thread-1-webiny.vercel.app/docs/headless-cms/extending/content-models-via-code#how-to-set-a-default-value-of-a-field)