### PR TITLE
fix: update to latest react-properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@sindresorhus/slugify": "^1.1.0",
     "@svgr/webpack": "^5.5.0",
     "@tailwindcss/typography": "^0.5.0",
-    "@webiny/react-properties": "^5.34.1",
+    "@webiny/react-properties": "unstable",
     "autoprefixer": "^10.4.0",
     "babel-plugin-module-resolver": "^4.1.0",
     "brotli-size": "^4.0.0",

--- a/scripts/versionedDocs/prepareDocs.js
+++ b/scripts/versionedDocs/prepareDocs.js
@@ -73,10 +73,6 @@ export async function prepareDocs() {
     // Copy pages of the "latest" version.
     const latestPages = catalog.filter(p => p.version === "latest");
     for (const page of latestPages) {
-        if (!page.relativePath) {
-            console.log(JSON.stringify(page, null, 2));
-            throw new Error(`Page doesn't have a "relativePath" set!`);
-        }
         await fs.copy(page.sourceFile, targetDocsPath(page.relativePath + ".mdx"));
     }
     injectVersion(targetDocsPath(), "latest");
@@ -87,10 +83,6 @@ export async function prepareDocs() {
         const targetPath = targetDocsPath(version);
         // Copy shared pages first
         for (const page of versionPages) {
-            if (!page.relativePath) {
-                console.log(JSON.stringify(page, null, 2));
-                throw new Error(`Page doesn't have a "relativePath" set!`);
-            }
             await fs.copy(page.sourceFile, targetDocsPath(page.relativePath + ".mdx"));
         }
         injectVersion(targetPath, version);
@@ -113,10 +105,6 @@ export async function prepareDocs() {
     });
 
     info(`Docs are ready for building!`);
-    return new Promise(resolve => {
-        info(`Wait for 5 seconds for file system to cool down before proceeding...`);
-        setTimeout(resolve, 5000);
-    });
 }
 
 export async function generateNavigation(realVersion, navigationSource) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1535,12 +1535,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:7.19.0":
-  version: 7.19.0
-  resolution: "@babel/runtime@npm:7.19.0"
+"@babel/runtime@npm:7.20.13":
+  version: 7.20.13
+  resolution: "@babel/runtime@npm:7.20.13"
   dependencies:
-    regenerator-runtime: ^0.13.4
-  checksum: fa69c351bb05e1db3ceb9a02fdcf620c234180af68cdda02152d3561015f6d55277265d3109815992f96d910f3db709458cae4f8df1c3def66f32e0867d82294
+    regenerator-runtime: ^0.13.11
+  checksum: 09b7a97a05c80540db6c9e4ddf8c5d2ebb06cae5caf3a87e33c33f27f8c4d49d9c67a2d72f1570e796045288fad569f98a26ceba0c4f5fad2af84b6ad855c4fb
   languageName: node
   linkType: hard
 
@@ -2417,15 +2417,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@webiny/react-properties@npm:^5.34.1":
-  version: 5.34.1
-  resolution: "@webiny/react-properties@npm:5.34.1"
+"@webiny/react-properties@npm:unstable":
+  version: 0.0.0-unstable.d7f521b032
+  resolution: "@webiny/react-properties@npm:0.0.0-unstable.d7f521b032"
   dependencies:
-    "@babel/runtime": 7.19.0
+    "@babel/runtime": 7.20.13
     "@types/react": 17.0.39
     nanoid: 3.3.4
     react: 17.0.2
-  checksum: 39d3c4c199e92b49e906f4bd7f33e9ad5a7b4cdb8fef09dc4600c08f37023f95d3332f6de431d067aa64e9c332b8e495228407e988160433a9efa14b18cc0f2b
+  checksum: bb9a5081fc3ff19f9b086098645b689d6e8b93ddce857328f7944f6110090e50fe262ccb5a4a2ab1886fb8492c605e4ff44cfd10f806e3d1e87df870deb088f2
   languageName: node
   linkType: hard
 
@@ -8059,6 +8059,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
+  languageName: node
+  linkType: hard
+
 "regenerator-runtime@npm:^0.13.4":
   version: 0.13.9
   resolution: "regenerator-runtime@npm:0.13.9"
@@ -8437,7 +8444,7 @@ __metadata:
     "@tailwindcss/typography": ^0.5.0
     "@typescript-eslint/eslint-plugin": 2.x
     "@typescript-eslint/parser": 2.x
-    "@webiny/react-properties": ^5.34.1
+    "@webiny/react-properties": unstable
     autoprefixer: ^10.4.0
     babel-eslint: 10.x
     babel-plugin-module-resolver: ^4.1.0


### PR DESCRIPTION
## Short Description
Update to the `unstable` version of `@webiny/react-properties`, which contains a fix for unique property id generation. The IDs were not unique enough for the amount of properties being generated, and that caused the generated page data to be corrupted, thus making the build fail.

