### PR TITLE
docs: fixed typo in release notes

### DIFF
--- a/src/docs/shared/release-notes/5.35.0/removing-the-headless-cms-lambda-function.mdx
+++ b/src/docs/shared/release-notes/5.35.0/removing-the-headless-cms-lambda-function.mdx
@@ -59,7 +59,7 @@ The migration consists of a couple of relatively simple steps:
 
 ## Cleanup
 
-After you have migrated all your plugins and other related application code, deployed and tested the project, feel free to delete the `apps/api/headless/CMS` folder.
+After you have migrated all your plugins and other related application code, deployed and tested the project, feel free to delete the `apps/api/headlessCMS` folder.
 
 ## Conclusion
 


### PR DESCRIPTION
## Short Description
Fix a typo on the page

## Relevant Links
https://www.webiny.com/docs/release-notes/5.35.0/removing-the-headless-cms-lambda-function