### PR TITLE
Add html sanatization topic or legacy RTE renderer article

### DIFF
--- a/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
+++ b/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
@@ -5,6 +5,7 @@ description: Learn how to render rich text content from Headless CMS.
 
 import Link from "next/link";
 import { Alert } from "@/components/Alert";
+import {CanIUseThis} from "@/components/CanIUseThis";
 
 <Alert type="warning">
   This document covers rendering of rich text content via the legacy Rich Text Editor, which was deprecated with the <Link href={"../../release-notes/5.37.0/changelog"}>5.37.0 release</Link>. For the latest information, please visit the new <Link href={"./render-lexical-rich-text-content"}>Render Rich Text Content</Link> article.
@@ -127,8 +128,7 @@ If you don't want to use the default styles, skip this import and implement your
 
 ## HTML Sanitization
 
-When rendering the rich text content, we’re sanitizing the HTML using the [sanitize-html](https://www.npmjs.com/package/sanitize-html) package,
-to prevent the possibility of an XSS attack.
+In order to minimize the possibility of [cross-site scripting (XSS) attacks](https://en.wikipedia.org/wiki/Cross-site_scripting), the HTML that’s returned by the legacy rich text editor is sanitized, which is done with the help of the [sanitize-html](https://www.npmjs.com/package/sanitize-html) library.
 
 ### Sanitization configuration
 
@@ -137,7 +137,7 @@ To provide sanitize configuration to specific component, use `sanitizationConfig
 
 Please check `sanitize-html` configuration options on their [GitHub page](https://github.com/apostrophecms/sanitize-html).
 
-```tsx App.tsx
+```tsx myView.tsx
 import {
   RichTextRenderer,
   configureSanitization,
@@ -165,9 +165,8 @@ const sanitizationConfig = {
 
 <RichTextRenderer sanitizationConfig={sanitizationConfig} />;
 ```
-<Alert type={"danger"}>
-  Important! Update this component to version 5.37.2 or higher to improve security of your website.
-</Alert>
+
+<CanIUseThis title={"CAN I USE THIS?"} since={"5.37.2"} />
 
 ## FAQ
 

--- a/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
+++ b/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
@@ -1,5 +1,5 @@
 ---
-title: (Legacy)Render Rich Text Content
+title: (Legacy) Render Rich Text Content
 description: Learn how to render rich text content from Headless CMS.
 ---
 
@@ -128,14 +128,14 @@ If you don't want to use the default styles, skip this import and implement your
 
 ## HTML Sanitization
 
-In order to minimize the possibility of [cross-site scripting (XSS) attacks](https://en.wikipedia.org/wiki/Cross-site_scripting), the HTML that’s returned by the legacy rich text editor is sanitized, which is done with the help of the [sanitize-html](https://www.npmjs.com/package/sanitize-html) library.
+<CanIUseThis title={"CAN I USE THIS?"} since={"5.37.2"} />
+
+In order to minimize the possibility of [cross-site scripting (XSS) attacks](https://en.wikipedia.org/wiki/Cross-site_scripting), the HTML that’s returned by the rich text editor is sanitized, which is done with the help of the [sanitize-html](https://www.npmjs.com/package/sanitize-html) library.
 
 ### Sanitization configuration
 
 Use `configureSanitization` function to set your global sanitization preference.
 To provide sanitize configuration to specific component, use `sanitizationConfig` prop.
-
-Please check `sanitize-html` configuration options on their [GitHub page](https://github.com/apostrophecms/sanitize-html).
 
 ```tsx myView.tsx
 import {
@@ -166,10 +166,4 @@ const sanitizationConfig = {
 <RichTextRenderer sanitizationConfig={sanitizationConfig} />;
 ```
 
-<CanIUseThis title={"CAN I USE THIS?"} since={"5.37.2"} />
-
-## FAQ
-
-### I'm not using React. How do I render this using other frameworks?
-
-The rendering implementation is really simple and straightforward. You can find the [full code in our repo](https://github.com/webiny/webiny-js/blob/next/packages/react-rich-text-renderer/src/index.tsx). Using that as a reference, you can quickly put together a renderer in the framework of your choice.
+Please check `sanitize-html` configuration options on their [GitHub page](https://github.com/apostrophecms/sanitize-html).

--- a/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
+++ b/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
@@ -125,6 +125,50 @@ Styles for default renderers are included in the package and you can import them
 
 If you don't want to use the default styles, skip this import and implement your own styling.
 
+## HTML Sanitization
+
+When rendering the rich text content, we’re sanitizing the HTML using the [sanitize-html](https://www.npmjs.com/package/sanitize-html) package,
+to prevent the possibility of an XSS attack.
+
+### Sanitization configuration
+
+Use `configureSanitization` function to set your global sanitization preference.
+To provide sanitize configuration to specific component, use `sanitizationConfig` prop.
+
+Please check `sanitize-html` configuration options on their [GitHub page](https://github.com/apostrophecms/sanitize-html).
+
+```tsx App.tsx
+import {
+  RichTextRenderer,
+  configureSanitization,
+} from "@webiny/react-rich-text-renderer";
+
+const globalSanitizaionConfig = {
+allowedTags: ["b", "i", "em", "strong", "a"],
+allowedAttributes: {
+a: ["href"],
+},
+allowedIframeHostnames: ["www.youtube.com"],
+};
+
+// This is global configuration.
+configureSanitization(globalSanitizaionConfig);
+
+/*
+* Set sanitization configuration options for specific component.
+* Note: Provided configuration will override your global configuration options.
+* */
+const sanitizationConfig = {
+// change the configuration only for this option.
+allowedIframeHostnames: ["www.webiny.com"],
+};
+
+<RichTextRenderer sanitizationConfig={sanitizationConfig}/>;
+```
+<Alert type={"danger"}>
+  Important! Update this component to version 5.37.2 or higher to improve security of your website.
+</Alert>
+
 ## FAQ
 
 ### I'm not using React. How do I render this using other frameworks?

--- a/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
+++ b/src/docs/5.37.x/headless-cms/integrations/legacy-render-rich-text-content.mdx
@@ -144,26 +144,26 @@ import {
 } from "@webiny/react-rich-text-renderer";
 
 const globalSanitizaionConfig = {
-allowedTags: ["b", "i", "em", "strong", "a"],
-allowedAttributes: {
-a: ["href"],
-},
-allowedIframeHostnames: ["www.youtube.com"],
+  allowedTags: ["b", "i", "em", "strong", "a"],
+  allowedAttributes: {
+    a: ["href"],
+  },
+  allowedIframeHostnames: ["www.youtube.com"],
 };
 
 // This is global configuration.
 configureSanitization(globalSanitizaionConfig);
 
 /*
-* Set sanitization configuration options for specific component.
-* Note: Provided configuration will override your global configuration options.
-* */
+ * Set sanitization configuration options for specific component.
+ * Note: Provided configuration will override your global configuration options.
+ * */
 const sanitizationConfig = {
-// change the configuration only for this option.
-allowedIframeHostnames: ["www.webiny.com"],
+  // change the configuration only for this option.
+  allowedIframeHostnames: ["www.webiny.com"],
 };
 
-<RichTextRenderer sanitizationConfig={sanitizationConfig}/>;
+<RichTextRenderer sanitizationConfig={sanitizationConfig} />;
 ```
 <Alert type={"danger"}>
   Important! Update this component to version 5.37.2 or higher to improve security of your website.


### PR DESCRIPTION
With this PR we want to add a new topic to the legacy rich text renderer article where we describe the sanitization option and call developers to upgrade the version of this component to `5.37.2` to improve the security of their website.

## Relevant Links
[Legacy RTE renderer page](https://docs-webiny-n62raqsxv-webiny.vercel.app/docs/headless-cms/integrations/legacy-render-rich-text-content)

## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->

## Screenshots (if relevant):
N/A
