### PR TITLE
docs: fix the sample code to configure the custom domain in website app, thanks to Sven.

### DIFF
--- a/src/docs/5.29.x/infrastructure/additional-resources/connect-custom-domain.mdx
+++ b/src/docs/5.29.x/infrastructure/additional-resources/connect-custom-domain.mdx
@@ -42,18 +42,20 @@ Read more about requirements for using alternate domain names in the official [A
 
 ## Configure the Custom Domain in the Website App
 
-```ts apps/website/webiny.application.ts
+
+```diff-ts apps/website/webiny.application.ts
 import { createWebsiteApp } from "@webiny/serverless-cms-aws";
 
 export default createWebsiteApp({
-  domains() {
-    return {
-      domains: ["my.domain.com"],
-      sslSupportMethod: "sni-only",
-      acmCertificateArn:
-        "arn:aws:acm:us-east-1:111111111111:certificate/5931d8b4-a39b-4a3a-a4e7-f5bbdd78d599"
-    };
-  }
+    pulumiResourceNamePrefix: "wby-",
++    domains() {
++      return {
++        domains: ["my.domain.com"],
++        sslSupportMethod: "sni-only",
++        acmCertificateArn:
++          "arn:aws:acm:us-east-1:636962863878:certificate/3baf9092-fb27-4efb-9409-XXXXXXXX"
++      };
++    }
 });
 ```
 


### PR DESCRIPTION
If the user just copy/paste the previous snippet their project will be deployed as a completely new one since they haven't included the pulumiResourceNamePrefix attribute which is by default present in their project. Thanks to Sven for reporting and sharing the updated code sample.

