### PR TITLE
fix: typo in the api code that allows the user to configure a shared-…

### DIFF
--- a/src/docs/5.36.x/infrastructure/basics/modify-cloud-infrastructure.mdx
+++ b/src/docs/5.36.x/infrastructure/basics/modify-cloud-infrastructure.mdx
@@ -320,7 +320,7 @@ import { createApiApp } from "@webiny/serverless-cms-aws";
 // Here we're listing all environments that will use the shared ElasticSearch domain.
 const ENVIRONMENTS_USING_SHARED_ES_DOMAIN = ["dev", "other-dev"];
 
-export default createCoreApp({
+export default createApiApp({
     pulumiResourceNamePrefix: "wby-",
     elasticSearch: ({ params }) => {
         const { env } = params.run;


### PR DESCRIPTION
…amazon-elasticsearch-cluster

## Short Description
- There was a typo in the Using a Shared Amazon Elasticsearch (OpenSearch) Domain section, where the API code wasn't referring to the corect app name, it was using createCoreApp instead of createApiApp

<!--- For help on writing docs, visit https://docs.webiny.com/docs/contributing/documentation -->

## Relevant Links

- [https://www.webiny.com/docs/infrastructure/basics/modify-cloud-infrastructure#using-a-shared-amazon-elasticsearch-open-search-domain](#)


## Checklist
- [ ] I added page metadata (description, keywords)
- [ ] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [ ] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [ ] I used title case for titles and subtitles (in the main menu and in the page content)
- [ ] I checked for typos and grammar mistakes
- [ ] I added `alt` / `title` attributes for inserted images (if any)
- [ ] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 

<!--- Resources:
- new document template: https://docs.webiny.com/docs/contributing/documentation#template-for-new-docs
- "What You'll Learn" example: https://docs.webiny.com/docs/how-to-guides/upgrade-webiny
- example of using title-case correctly: https://docs.webiny.com/docs/key-topics/deployment/iac-with-pulumi
- for title case checks - https://titlecaseconverter.com
- for typos and grammar checks - https://www.grammarly.com
-->


## Screenshots (if relevant):

![Screenshot 2023-10-25 at 14 01 40](https://github.com/webiny/docs.webiny.com/assets/76428679/30a9d2c4-2f15-426e-b241-688570bdae92)
