### PR TITLE
fix: column namespace

### DIFF
--- a/docs/developer-docs/5.39.x/file-manager/extending/customize-file-list-table-columns.mdx
+++ b/docs/developer-docs/5.39.x/file-manager/extending/customize-file-list-table-columns.mdx
@@ -75,19 +75,19 @@ The following code examples are built using the [custom file field](/docs/{versi
 
 ## Add a Column
 
-To add a new column, use the `Browser.Column` component and mount it within your Admin app. This component will serve as the foundation for your columns.
+To add a new column, use the `Browser.Table.Column` component and mount it within your Admin app. This component will serve as the foundation for your columns.
 
 ### Simple Column
 
 Here is an example of creating a column to show the `copyright` field data within the table. 
-The `Browser.Column` component receives the following mandatory props:
+The `Browser.Table.Column` component receives the following mandatory props:
 
 - `name` used to target the field you want to show and serves as a unique identifier
 - `header` used for formatting the column header
 
 ```tsx
 <FileManagerViewConfig>
-  <Browser.Column
+  <Browser.Table.Column
     name={"extensions.copyright"}
     header={"Copyright"}
   />   
@@ -135,7 +135,7 @@ Using the `cell` prop, you can pass the custom component to the column definitio
 
 ```diff-tsx
   <FileManagerViewConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"extensions.copyright"}
       header={"Copyright"}
 +     cell={<CellCopyright />}
@@ -154,7 +154,7 @@ In addition, you can allow or disallow users to adjust the column width accordin
 
 ```diff-tsx
   <FileManagerViewConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"extensions.copyright"}
       header={"Copyright"}
 +     size={75}
@@ -171,7 +171,7 @@ Users have the ability to show/hide columns by using the column settings menu.
 
 ```diff-tsx
   <FileManagerViewConfig>
-    <Browser.Column
+    <Browser.Table.Column
      name={"extensions.copyright"}
       header={"Copyright"}
 +     visible={false}
@@ -187,7 +187,7 @@ When the `hideable` property is set to false, users are restricted from dynamica
 
 ```diff-tsx
   <FileManagerViewConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}
@@ -204,7 +204,7 @@ You can easily add custom CSS class names to columns using the `className` prope
 
 ```diff-tsx
   <FileManagerViewConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"extensions.copyright"}
       header={"Copyright"}
 +     className={"custom-copyright-className"}

--- a/docs/developer-docs/5.39.x/headless-cms/extending/customize-entry-list-table-columns.mdx
+++ b/docs/developer-docs/5.39.x/headless-cms/extending/customize-entry-list-table-columns.mdx
@@ -78,19 +78,19 @@ The code examples below are based on a content model called `Property` with the 
 
 ## Add a Column
 
-To add a new column, use the `Browser.Column` component and mount it within your Admin app. This component will serve as the foundation for your columns.
+To add a new column, use the `Browser.Table.Column` component and mount it within your Admin app. This component will serve as the foundation for your columns.
 
 ### Simple Column
 
 Here is an example of creating a column to show the `price` field data within the table. 
-The `Browser.Column` component receives the following mandatory props:
+The `Browser.Table.Column` component receives the following mandatory props:
 
 - `name` used to target the field you want to show and serves as a unique identifier
 - `header` used for formatting the column header
 
 ```tsx
 <ContentEntryListConfig>
-  <Browser.Column
+  <Browser.Table.Column
     name={"price"}
     header={"Price"}
     modelIds={["property"]}
@@ -136,7 +136,7 @@ Using the `cell` prop, you can pass the custom component to the column definitio
 
 ```diff-tsx
   <ContentEntryListConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}
@@ -152,7 +152,7 @@ You can enable sorting by setting the `sortable` property, so users can sort the
 
 ```diff-tsx
   <ContentEntryListConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}
@@ -172,7 +172,7 @@ In addition, you can allow or disallow users to adjust the column width accordin
 
 ```diff-tsx
   <ContentEntryListConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}
@@ -190,7 +190,7 @@ Users have the ability to show/hide columns by using the column settings menu.
 
 ```diff-tsx
   <ContentEntryListConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}
@@ -207,7 +207,7 @@ When the `hideable` property is set to false, users are restricted from dynamica
 
 ```diff-tsx
   <ContentEntryListConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}
@@ -224,7 +224,7 @@ You can easily add custom CSS class names to columns using the `className` prope
 
 ```diff-tsx
   <ContentEntryListConfig>
-    <Browser.Column
+    <Browser.Table.Column
       name={"price"}
       header={"Price"}
       modelIds={["property"]}


### PR DESCRIPTION
## Short Description
With this PR, we aim to fix the namespace for column configurations from the `Browser.Column` to `Browser.Table.Column`.

## Relevant Links
- [File Manager](https://www.webiny.com/docs/file-manager/extending/customize-file-list-table-columns)
- [Headless CMS](https://www.webiny.com/docs/headless-cms/extending/customize-entry-list-table-columns)

## Screenshots (if relevant):
N/A
