### PR TITLE
fix camelcase for openSearchDomainVpcConfig var reference in upgrade 5.43 notes

### DIFF
--- a/docs/release-notes/5.43.0/changelog.mdx
+++ b/docs/release-notes/5.43.0/changelog.mdx
@@ -199,7 +199,7 @@ export default createCoreApp({
 });
 ```
 
-With this release, the underlying issue should no longer occur, and the above configuration will work as expected—with one minor change: instead of using `elasticSearchDomainVpcConfig`, users should now use `opensearchDomainVpcConfig`.
+With this release, the underlying issue should no longer occur, and the above configuration will work as expected—with one minor change: instead of using `elasticSearchDomainVpcConfig`, users should now use `openSearchDomainVpcConfig`.
 
 For more information on this change and also how to upgrade your existing Webiny project, please refer to the [5.43.0 migration guide](/docs/release-notes/5.43.0/upgrade-guide) guide.
 

--- a/docs/release-notes/5.43.0/upgrade-guide.mdx
+++ b/docs/release-notes/5.43.0/upgrade-guide.mdx
@@ -77,7 +77,7 @@ export default createCoreApp({
 });
 ```
 
-With this release, the underlying issue should no longer occur, and the above configuration will work as expected—with one minor change: instead of using `elasticSearchDomainVpcConfig`, users should now use `opensearchDomainVpcConfig`. So, the above code should be updated to the following:
+With this release, the underlying issue should no longer occur, and the above configuration will work as expected—with one minor change: instead of using `elasticSearchDomainVpcConfig`, users should now use `openSearchDomainVpcConfig`. So, the above code should be updated to the following:
 
 ```ts apps/core/webiny.application.ts
 import { createCoreApp } from "@webiny/serverless-cms-aws/enterprise";
@@ -93,7 +93,7 @@ export default createCoreApp({
   openSearch: true,
   vpc: {
     useExistingVpc: {
-      opensearchDomainVpcConfig: {
+      openSearchDomainVpcConfig: {
         subnetIds: OPENSEARCH_PRIVATE_SUBNETS,
         securityGroupIds: OPENSEARCH_SECURITY_GROUPS
       },


### PR DESCRIPTION
## Short Description
Corrects the variable reference from `opensearchDomainVpcConfig` to `openSearchDomainVpcConfig`. Using the former returns a pulumi error:
```
Diagnostics:
  pulumi:pulumi:Stack (core-hosvr):
    error: Running program '/home/jho/repos/ASCO.webiny/.webiny/workspaces/apps/core/pulumi/' failed with an unhandled exception:
    Error: Cannot specify `useExistingVpc` parameter because the `openSearchDomainVpcConfig` parameter wasn't provided.
```

## Relevant Links
- [update variable reference in 5.43 upgrade guide](https://www.webiny.com/docs/release-notes/5.43.0/upgrade-guide)
- [update var reference in change log](https://www.webiny.com/docs/release-notes/5.43.0/changelog)

## Checklist
- [n/a] I added page metadata (description, keywords)
- [n/a] I've added "Can I Use This?" section (if needed, e.g. if documenting a new feature)
- [n/a] I added `What You'll Learn` at the top of the page and every item in the list starts with a lower case letter
- [n/a] I used title case for titles and subtitles (in the main menu and in the page content)
- [n/a] I checked for typos and grammar mistakes
- [n/a] I added `alt` / `title` attributes for inserted images (if any)
- [n/a] When linking code from GitHub, I did it via a specific tag (and not `next` / `v5` branch) 
