### PR TITLE
docs: update private model documentation

### DIFF
--- a/docs/developer-docs/5.40.x/headless-cms/extending/private-models.mdx
+++ b/docs/developer-docs/5.40.x/headless-cms/extending/private-models.mdx
@@ -414,7 +414,7 @@ Let's register all these plugins. Create a `src/books.app.ts` file. This file se
 ```tsx books.app.ts
 import { ContextPlugin } from "@webiny/handler-aws";
 import { Context } from "./types";
-import { CmsModelPlugin } from "@webiny/api-headless-cms";
+import { CmsModelPlugin, isHeadlessCmsReady } from "@webiny/api-headless-cms";
 import WebinyError from "@webiny/error";
 import { booksGraphql } from "./books.graphql";
 import { BOOK_MODEL_ID, createBookModel } from "./book.model";
@@ -423,6 +423,11 @@ import { BooksCrud } from "./books.crud";
 
 export const createBooksApp = () => {
   return new ContextPlugin<Context>(async context => {
+    // Exit early if Headless CMS is not installed.
+    if (!(await isHeadlessCmsReady(context))) {
+        return;
+    }
+
     // Registering the private model.
     context.plugins.register(new CmsModelPlugin(createBookModel()));
 


### PR DESCRIPTION
During the installation wizard of Webiny loading the private model does cause an error. The reason is that loading models requires i18n, but when the installation wizard launches, the setup of i18n is not done yet.

This minor documentation patch will update the example code of the books app to show case how to check if the CMS is already installed.

Only if the CMS is installed, the apps ContextPlugin code will be run.

Helped-by: Pavel Denisjuk <pavel@webiny.com>

---

CC: @swapnilmmane 