### PR TITLE
fix: yarnrc security

### DIFF
--- a/docs/developer-docs/6.x/infrastructure/yarnrc-security.mdx
+++ b/docs/developer-docs/6.x/infrastructure/yarnrc-security.mdx
@@ -119,7 +119,7 @@ A longer duration provides more protection but delays access to new releases. A 
 
 Webiny validates every release against a `3d` age gate. This means all third-party dependencies included in a Webiny release are guaranteed to be at least three days old at the time of release - but not necessarily older than that.
 
-If you set a stricter age gate (for example `7d`) and install a new Webiny version on release day, Yarn may reject third-party dependencies that Webiny relies on because they are older than three days but younger than seven days. The `npmPreapprovedPackages` list only exempts `@webiny/*` packages - it does not cover the third-party packages that Webiny depends on.
+If you set a stricter age gate (for example `7d`) and install a new Webiny version on release day, Yarn will reject any third-party dependency that Webiny relies on if it was published less than seven days ago. The `npmPreapprovedPackages` list only exempts `@webiny/*` packages - it does not cover the third-party packages that Webiny depends on.
 
 To avoid this, either keep the default `3d` value, or wait the difference between your age gate and `3d` after a Webiny release before upgrading. For example, with `7d`, wait four days after the release.
 

--- a/docs/developer-docs/6.x/infrastructure/yarnrc-security.mdx
+++ b/docs/developer-docs/6.x/infrastructure/yarnrc-security.mdx
@@ -115,6 +115,16 @@ npmMinimalAgeGate: 1d
 
 A longer duration provides more protection but delays access to new releases. A shorter duration gives faster access but reduces the window for malicious packages to be caught.
 
+<Alert type="warning" title="Compatibility with Webiny releases">
+
+Webiny validates every release against a `3d` age gate. This means all third-party dependencies included in a Webiny release are guaranteed to be at least three days old at the time of release - but not necessarily older than that.
+
+If you set a stricter age gate (for example `7d`) and install a new Webiny version on release day, Yarn may reject third-party dependencies that Webiny relies on because they are older than three days but younger than seven days. The `npmPreapprovedPackages` list only exempts `@webiny/*` packages - it does not cover the third-party packages that Webiny depends on.
+
+To avoid this, either keep the default `3d` value, or wait the difference between your age gate and `3d` after a Webiny release before upgrading. For example, with `7d`, wait four days after the release.
+
+</Alert>
+
 ## Approved Git Repositories
 
 ```yaml .yarnrc.yml
@@ -145,6 +155,12 @@ The age gate blocked a package version. You have three options:
 - **Wait** - try again after the age gate duration has passed
 - **Preapprove** - add the package to `npmPreapprovedPackages` if you trust the publisher
 - **Lower the gate** - reduce `npmMinimalAgeGate` (not recommended unless you understand the risk)
+
+<Alert type="info" title="Seeing this right after a Webiny upgrade?">
+
+If this error appears immediately after upgrading to a new Webiny version, your age gate is likely stricter than the `3d` default that Webiny uses. Third-party dependencies in the release may not yet meet your gate. Either wait for the packages to age past your threshold, or lower your age gate to `3d` to match Webiny's release process.
+
+</Alert>
 
 ### "Lifecycle scripts are disabled"
 


### PR DESCRIPTION
## Summary

  - Added a warning alert in the age gate section explaining that Webiny validates releases against a `3d` age gate, so stricter values (e.g. `7d`) will cause Yarn to reject
  third-party dependencies on release day
  - Added an info alert in the troubleshooting section to help users who hit this error right after a Webiny upgrade

## Test plan

  - [x] Verify the page renders correctly in the docs site
  - [x] Confirm both alerts display with the correct type and title