### PR TITLE
Release 6.5.0

### DIFF
--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -181,6 +181,17 @@ const MySlugify = Slugify.createDecorator(() => ({
 container.registerDecorator(MySlugify);
 ```
 
+### Scheduled Publish/Unpublish State Now Visible Across the CMS UI ([#5441](https://github.com/webiny/webiny-js/pull/5441))
+{/* REVIEW-PENDING @adrians5j — confirm this entry, then delete this line */}
+
+Previously, scheduled publish/unpublish actions were only visible inside the schedule dialog. Now the scheduled state appears everywhere users expect to see publish status:
+
+- **Entries list "Live" column**: Shows a `Scheduled` pill with the go-live time when an entry has a pending action. Entries can display both "Live" and "Scheduled" simultaneously when an older revision is live and a newer one is queued.
+- **Entry form banner**: An amber info banner appears above the form when the open entry has a scheduled action.
+- **Publish/Unpublish confirm dialogs**: A warning appears when the entry has a scheduled action, explaining that publishing now will cancel the scheduled action.
+
+The UI refreshes automatically when you schedule, cancel, publish, or unpublish — no page reload required.
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))
@@ -269,6 +280,30 @@ The installer's auto-generated API key for the frontend was missing `wb.*` read 
 Existing environments are unaffected by new installs — if your redirects stopped working after a recent deploy, manually edit the Website Builder API key in Admin and grant it Read access.
 
 </Alert>
+
+### New `contentEntry` Input Type for CMS-Connected Components ([#5594](https://github.com/webiny/webiny-js/pull/5594))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+Website Builder components can now consume CMS entries directly via a new `contentEntry` input type. This enables three modes of content binding:
+
+- **Manual single**: Select a specific entry by ID
+- **Manual list**: Select multiple specific entries
+- **Query**: Define a dynamic query with model, sort, limit, and search parameters
+
+```typescript
+import { createContentEntryInput } from "webiny/website-builder-sdk";
+
+const input = createContentEntryInput({
+  mode: "query",
+  models: ["article"],
+  query: {
+    sort: "createdOn_DESC",
+    limit: 10
+  }
+});
+```
+
+Content entries are resolved server-side during SSR, so pages with CMS-connected components render correctly on first load. A `useContentEntryList` React hook is available for client-side pagination in query mode.
 
 ## Admin
 

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -132,6 +132,55 @@ Existing content models using the `file` field will continue to work. You can mi
 
 The CMS entry revision comparison feature has been relocated from the `/extensions` folder into the `@webiny/ai-powerups` package. This change consolidates AI-powered features in a single package and adds proper architectural layering with UseCase, Repository, and Gateway patterns. The `compareEntryRevisions` GraphQL query is now nested under `CmsQuery`, accessed via `cms { compareEntryRevisions(...) }`.
 
+### New Asset Field with Non-Destructive Crop and Focal Point ([#5452](https://github.com/webiny/webiny-js/pull/5452))
+{/* REVIEW-PENDING @SvenAlHamad — confirm this entry, then delete this line */}
+
+A new first-class **Asset** field replaces the bare-URL `file` field for images. It stores crop coordinates, focal point, alt text, and caption — all non-destructively. The original file is never modified; edits are applied server-side at delivery time, producing a URL that works with any frontend framework.
+
+```typescript
+import { fields } from "webiny/api-headless-cms";
+
+const model = {
+  fields: [
+    fields.asset("heroImage").imagesOnly(),
+    fields.asset("document").accept(["application/pdf"])
+  ]
+};
+```
+
+The Asset field exposes a resolved `url` in the read API with crop and focal point baked in, so frontends get a turnkey URL without knowing the delivery-param contract. The underlying `src` remains the pristine original.
+
+**Image editor** — File Manager, CMS file fields, and the new Asset input all share the same crop/focal-point editor. Choose from aspect-ratio presets or enter a custom ratio; a live preview shows the result.
+
+**Delivery URL parameters** — `?crop=t,l,b,r`, `?aspectRatio=16:9`, and `?focal=x,y` join the existing `?width`, `?format`, and `?quality` params. The server computes the largest rectangle of the requested aspect ratio inside the crop, centered on the focal point.
+
+Existing `file` fields are unaffected. The legacy flat value is upgraded at render time with no migration needed.
+
+### Injectable String Formatting on the API ([#5526](https://github.com/webiny/webiny-js/pull/5526))
+{/* REVIEW-PENDING @adrians5j — confirm this entry, then delete this line */}
+
+`StringFormatter`, `Slugify`, and `DateFormatter` are now available in `@webiny/api-core`, mirroring the admin-side features. Server code can inject them for consistent, decoratable formatting.
+
+```typescript
+class MyRepository {
+  constructor(private stringFormatter: StringFormatter.Interface) {}
+
+  private makeSlug(name: string) {
+    return this.stringFormatter.slugify(name);
+  }
+}
+```
+
+To override slug logic project-wide, decorate the fine-grained `Slugify` feature:
+
+```typescript
+const MySlugify = Slugify.createDecorator(() => ({
+  execute: value => value.trim().toLowerCase().replace(/\s+/g, "_")
+}));
+
+container.registerDecorator(MySlugify);
+```
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))
@@ -198,6 +247,29 @@ Live preview in the CMS entry editor now correctly updates when you change asset
 - Asset URLs recompute immediately when crop settings change
 - The editing SDK only activates when the preview iframe is showing a CMS entry
 
+### Fixed Redirect Type Changes Not Invalidating the CDN Cache ([#5505](https://github.com/webiny/webiny-js/pull/5505))
+{/* REVIEW-PENDING @adrians5j — confirm this entry, then delete this line */}
+
+Changing a redirect from Permanent to Temporary (or vice versa) wrote to the database but never flushed CloudFront. The response is cached for up to a year, so the old redirect type kept being served. The type field is now included in the cache-invalidation check.
+
+The Admin dialog also now explains the difference between the two options:
+
+- **Temporary** — browsers check with the server on each visit, so you can change or remove this redirect later.
+- **Permanent** — browsers remember it indefinitely and may keep redirecting even after you change or delete it.
+
+New redirects now default to Temporary. The option you get by not choosing shouldn't be the one you can't undo.
+
+### Fixed Frontend API Key Missing Read Permission for Redirects ([#5531](https://github.com/webiny/webiny-js/pull/5531))
+{/* REVIEW-PENDING @adrians5j — confirm this entry, then delete this line */}
+
+The installer's auto-generated API key for the frontend was missing `wb.*` read permission. This caused `GET /wb/redirects` to return a 403, breaking redirect resolution on the frontend. The permission has been restored.
+
+<Alert type="info">
+
+Existing environments are unaffected by new installs — if your redirects stopped working after a recent deploy, manually edit the Website Builder API key in Admin and grant it Read access.
+
+</Alert>
+
 ## Admin
 
 ### Workflow State Folder Permissions ([#5331](https://github.com/webiny/webiny-js/pull/5331))
@@ -247,6 +319,26 @@ The API key slug for frontend integration has been renamed from `website-builder
 ### Tenant Theme Extension with Font Selector ([#5507](https://github.com/webiny/webiny-js/pull/5507))
 
 A new `TenantThemeExtension` has been added to the Next.js starter kit, enabling per-tenant theme customization including a font selector. Themes are merged at runtime based on the current tenant.
+
+### Dark Theme Support ([#5316](https://github.com/webiny/webiny-js/pull/5316))
+{/* REVIEW-PENDING @SvenAlHamad — confirm this entry, then delete this line */}
+
+The Admin UI now supports multiple themes, including dark mode. You can register custom themes through an extension, and several dark themes are included as sample implementations.
+
+### Injectable String Formatting ([#5517](https://github.com/webiny/webiny-js/pull/5517))
+{/* REVIEW-PENDING @adrians5j — confirm this entry, then delete this line */}
+
+`StringFormatter` and `Slugify` are now injectable features in `@webiny/app-admin`. They replace direct imports of the `slugify` npm package scattered across presenters, giving you a single, decoratable seam for slug generation.
+
+```typescript
+const MySlugify = Slugify.createDecorator(() => ({
+  execute: value => value.trim().toLowerCase().replace(/\s+/g, "_")
+}));
+
+container.registerDecorator(MySlugify);
+```
+
+Consumers call `stringFormatter.slugify()`; projects that need custom logic decorate `Slugify` alone rather than the whole formatter.
 
 ## Development
 

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -192,6 +192,11 @@ Previously, scheduled publish/unpublish actions were only visible inside the sch
 
 The UI refreshes automatically when you schedule, cancel, publish, or unpublish — no page reload required.
 
+### Fixed Image Crop Not Being Applied During Asset Delivery ([#5595](https://github.com/webiny/webiny-js/pull/5595))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+When you cropped an image using the File Manager's ImageEditor, the crop was saved correctly but never actually applied when the image was delivered. The image transformation pipeline was reading crop data from the wrong metadata path. This has been fixed — crops set via the ImageEditor UI are now properly applied during asset delivery.
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -197,6 +197,34 @@ The UI refreshes automatically when you schedule, cancel, publish, or unpublish 
 
 When you cropped an image using the File Manager's ImageEditor, the crop was saved correctly but never actually applied when the image was delivered. The image transformation pipeline was reading crop data from the wrong metadata path. This has been fixed — crops set via the ImageEditor UI are now properly applied during asset delivery.
 
+### Stable `_id` Property for Object and Dynamic Zone Field Values ([#5606](https://github.com/webiny/webiny-js/pull/5606))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+Object fields and dynamic zone fields now include a server-generated `_id` property on each value, giving external systems (comments, annotations, collaboration tools) a stable reference identifier for individual items within nested structures.
+
+```typescript
+// Example GraphQL response with the new _id property
+{
+  "data": {
+    "getArticle": {
+      "authors": [
+        { "_id": "abc123xyz456", "name": "John Doe" },
+        { "_id": "def789uvw012", "name": "Jane Smith" }
+      ],
+      "content": [
+        { "_id": "ghi345rst678", "_templateId": "heroBlock", "title": "Welcome" }
+      ]
+    }
+  }
+}
+```
+
+Key behaviors:
+- IDs are auto-generated on create/update using a 12-character alphanumeric identifier
+- Existing IDs are preserved when updating entries — only new items receive new IDs
+- Client-provided IDs are accepted; duplicates within the same array are silently regenerated
+- Existing entries return `_id: null` until re-saved (no data migration required)
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -225,6 +225,16 @@ Key behaviors:
 - Client-provided IDs are accepted; duplicates within the same array are silently regenerated
 - Existing entries return `_id: null` until re-saved (no data migration required)
 
+### Revision List Now Refreshes Automatically After Changes ([#5614](https://github.com/webiny/webiny-js/pull/5614))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+After creating or deleting a revision, the revisions drawer now re-fetches the list from the API. Previously, the list stayed stale until the drawer was closed and reopened.
+
+### Improved Revision List Actions and Visibility ([#5616](https://github.com/webiny/webiny-js/pull/5616), [#5617](https://github.com/webiny/webiny-js/pull/5617))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+The revision number in the revisions list is now more visible, and the revision list actions have been reorganised for better usability.
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -423,6 +423,11 @@ Consumers call `stringFormatter.slugify()`; projects that need custom logic deco
 
 When you deleted a folder while viewing it, you could end up stranded with no visible content. Now the UI automatically navigates to the nearest surviving ancestor folder (parent → grandparent → … → root) without requiring a manual navigation or page refresh. This also works when a folder is removed from the cache externally — for example, by another component calling `useDeleteFolder`. The fix uses optimistic cache updates instead of refetching from the API, avoiding issues with eventually-consistent storage.
 
+### Fixed Schema Validation for Empty Non-Required Fields ([#5642](https://github.com/webiny/webiny-js/pull/5642))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+Non-required fields with empty values (`null` or `undefined`) were incorrectly failing Zod schema validation, even though they should be allowed to remain empty. This affected scalar fields, object fields with all-empty children, and list fields with empty arrays. The validation logic now skips schema checks for non-required fields when their values are empty, while still validating populated fields and enforcing required field constraints as expected.
+
 ## Development
 
 ### Custom GraphQL Playground Built from Scratch ([#5357](https://github.com/webiny/webiny-js/pull/5357))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -418,6 +418,11 @@ container.registerDecorator(MySlugify);
 
 Consumers call `stringFormatter.slugify()`; projects that need custom logic decorate `Slugify` alone rather than the whole formatter.
 
+### Fixed Redirect After Deleting the Current Folder ([#5626](https://github.com/webiny/webiny-js/pull/5626))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+When you deleted a folder while viewing it, you could end up stranded with no visible content. Now the UI automatically navigates to the nearest surviving ancestor folder (parent → grandparent → … → root) without requiring a manual navigation or page refresh. This also works when a folder is removed from the cache externally — for example, by another component calling `useDeleteFolder`. The fix uses optimistic cache updates instead of refetching from the API, avoiding issues with eventually-consistent storage.
+
 ## Development
 
 ### Custom GraphQL Playground Built from Scratch ([#5357](https://github.com/webiny/webiny-js/pull/5357))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -276,6 +276,25 @@ Deleting the currently published revision left a stale `live` pointer on the ent
 
 Custom pattern validation fields with null or undefined flags caused `new RegExp(regex, null)` to crash. Falsy flags are now coerced to `undefined`, and validation errors now properly include field details in the GraphQL response.
 
+### Google AI Provider Support and Updated Model Lists ([#5670](https://github.com/webiny/webiny-js/pull/5670))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+Google is now available as an AI provider for AI Powerups, joining OpenAI and Anthropic. The integration uses Google's Gemini models including `gemini-3.8-flash`, `gemini-3.5-pro`, and `gemini-2.5-flash-lite` among others.
+
+Model lists for all providers have been updated to reflect current offerings:
+
+- **OpenAI**: Added `gpt-6-astra`, `gpt-5.5-pro`, `gpt-5.2`, `gpt-5.2-pro`, `gpt-5`, `gpt-5-pro`, `gpt-5-mini`, and `gpt-5-nano`
+- **Anthropic**: Added `claude-fable-5-1` and `claude-opus-4-8`, with flagship models now listed first
+- **Google**: 9 Gemini models available
+
+AI models now expose `deprecated` and `endOfLife` dates when known, allowing you to see which models are approaching end-of-life. Deprecated models (`o3-pro`, `o3`, `gpt-4.1-nano`, `o4-mini`) remain available for existing presets but will be removed after their shutdown dates.
+
+<Alert type="info">
+
+To use Google AI, set the `WEBINY_API_GOOGLE_API_KEY` environment variable or configure the API key through your provider preset.
+
+</Alert>
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -469,6 +469,24 @@ When you deleted a folder while viewing it, you could end up stranded with no vi
 
 Non-required fields with empty values (`null` or `undefined`) were incorrectly failing Zod schema validation, even though they should be allowed to remain empty. This affected scalar fields, object fields with all-empty children, and list fields with empty arrays. The validation logic now skips schema checks for non-required fields when their values are empty, while still validating populated fields and enforcing required field constraints as expected.
 
+### Unified Frontend Settings Configuration ([#5667](https://github.com/webiny/webiny-js/pull/5667))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+Frontend settings — including the preview domain and starter kit configuration — were previously tied to the Website Builder package. This made it awkward to configure frontend settings in projects not using Website Builder, or to share settings across multiple frontend frameworks.
+
+A new `@webiny/frontend-settings` package now manages these settings centrally:
+
+- **New GraphQL API:** `frontend { getSettings }` and `frontend { updateSettings }` provide a dedicated endpoint for frontend configuration, separate from Website Builder.
+- **Unified "Configure Frontend" dialog:** The Dev Tools dialog now includes a domain input field with save functionality. Starter kit configuration (Next.js, Nuxt) has been relocated here from Website Builder.
+- **New permission:** A `frontend.settings` permission controls access to the frontend settings API. Website Builder's `wb.settings` permission has been removed.
+
+If you were using the Website Builder "Settings" menu item to configure the preview domain, use the "Configure Frontend" dialog in Dev Tools instead. The `websiteBuilder { getSettings }` query still works but now delegates to the new frontend settings repository internally.
+
+### Removed Unused `useDataList` and `useAutocomplete` Hooks ([#5346](https://github.com/webiny/webiny-js/pull/5346))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+The `useDataList` and `useAutocomplete` hooks in the `@webiny/app` package had no usage across the codebase and have been removed. If you were importing these hooks directly, you'll need to implement equivalent functionality in your own code.
+
 ## Development
 
 ### Custom GraphQL Playground Built from Scratch ([#5357](https://github.com/webiny/webiny-js/pull/5357))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -295,6 +295,22 @@ To use Google AI, set the `WEBINY_API_GOOGLE_API_KEY` environment variable or co
 
 </Alert>
 
+### Unified Preview Domain Configuration for CMS Live Preview ([#5689](https://github.com/webiny/webiny-js/pull/5689))
+{/* REVIEW-PENDING @Pavel910 — confirm this entry, then delete this line */}
+
+CMS live preview now reads the preview domain from Frontend Settings instead of requiring per-model configuration. The `previewPrefix` and `previewSlug` model settings have been replaced with a single `previewPath` setting that defines only the URL path pattern. The preview domain is managed centrally in Frontend Settings.
+
+```typescript
+// Model configuration now uses previewPath only
+{
+  previewPath: "/articles/{values.slug}"
+}
+```
+
+When a path token cannot be resolved (e.g., `{values.slug}` on a new entry), the entire path falls back to `/new` rather than displaying an incomplete URL.
+
+The Frontend Settings permission has been moved to the Dev Tools permission group, and the "Configure Frontend" menu item is now gated by this permission.
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))

--- a/docs/release-notes/6.5.0/changelog.mdx
+++ b/docs/release-notes/6.5.0/changelog.mdx
@@ -235,6 +235,47 @@ After creating or deleting a revision, the revisions drawer now re-fetches the l
 
 The revision number in the revisions list is now more visible, and the revision list actions have been reorganised for better usability.
 
+### Revision Management Improvements ([#5618](https://github.com/webiny/webiny-js/pull/5618))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+The content entry revision system received significant usability improvements across the revision drawer, entry list, and form interfaces.
+
+**Revision drawer & list:**
+- The revision list now refreshes automatically after creating, deleting, unpublishing, or editing a note
+- Version numbers are more prominent — rows display `#N · Title` format
+- Each revision shows a visible status tag (Draft, Published, or Previously published) instead of tooltip-only status
+- Created-by and published-by information now appears on each revision
+- You can add or edit notes on any revision, not just at publish time
+- An alert banner warns when viewing an older revision with a link to the latest
+- Unpublish action is available in the 3-dots menu for published revisions
+
+**Content entries table:**
+- The Live column now shows a relative timestamp indicating when content was last published
+- Clicking the Live column header sorts entries by `lastPublishedOn`
+
+**Entry form:**
+- Clicking "+ New Revision" on a locked entry now navigates directly to the newly created revision URL
+
+### Timezone-Aware Scheduling ([#5618](https://github.com/webiny/webiny-js/pull/5618))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+The scheduler dialog now includes a timezone dropdown, allowing you to pick a scheduled time in any timezone. The picker converts your selection to UTC before sending to the backend. All scheduler date displays (alert bar, table tooltip, rescheduling dialog) now show consistent `UTC+02:00` format instead of the browser's inconsistent `GMT+2` output.
+
+### Fixed Revision Note Updates Overwriting Latest Revision ([#5618](https://github.com/webiny/webiny-js/pull/5618))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+Editing a note on an older revision would inadvertently overwrite the latest revision's content. A new `updateRevision` storage operation now writes only to the specific revision record without syncing to latest. This fix is implemented across DDB, DDB-ES, and SQL backends.
+
+### Fixed Stale Live Pointer After Deleting Published Revision ([#5618](https://github.com/webiny/webiny-js/pull/5618))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+Deleting the currently published revision left a stale `live` pointer on the entry. The system now correctly clears the `live` field when you delete a published revision.
+
+### Fixed Pattern Validator Crash with Null Flags ([#5618](https://github.com/webiny/webiny-js/pull/5618))
+{/* REVIEW-PENDING @brunozoric — confirm this entry, then delete this line */}
+
+Custom pattern validation fields with null or undefined flags caused `new RegExp(regex, null)` to crash. Falsy flags are now coerced to `undefined`, and validation errors now properly include field details in the GraphQL response.
+
 ## Website Builder
 
 ### Nuxt Starter Kit Configuration ([#5265](https://github.com/webiny/webiny-js/pull/5265))

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: t4yvzyhx
+id: m8y3q3qw
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: jt5c1ooo
+id: 6hargrnz
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: n8gm9dm7
+id: lb74chh3
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: j3rrck2s
+id: 464v62hp
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: uykjh2t4
+id: jt5c1ooo
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: ydmsyzsx
+id: 906qjzmb
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: m8y3q3qw
+id: jt5zuimv
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: 6hargrnz
+id: j3rrck2s
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: jt5zuimv
+id: uykjh2t4
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: 906qjzmb
+id: t4yvzyhx
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: 7nffwnm5
+id: ydmsyzsx
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: 464v62hp
+id: n8gm9dm7
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: azbp6dwk
+id: ljdnx672
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: ljdnx672
+id: xnmhf4xl
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: 2zogbsuj
+id: ee8ff4zs
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: xnmhf4xl
+id: 2zogbsuj
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: lb74chh3
+id: azbp6dwk
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---

--- a/docs/release-notes/6.5.0/upgrade-guide.mdx
+++ b/docs/release-notes/6.5.0/upgrade-guide.mdx
@@ -1,5 +1,5 @@
 ---
-id: ee8ff4zs
+id: primntvk
 title: Upgrade from 6.4.x to 6.5.0
 description: Learn how to upgrade Webiny from 6.4.x to 6.5.0.
 ---


### PR DESCRIPTION
Release PR for 6.5.0 (release/6.5.0 → master).

Recreated after the previous "Release 6.5.0" PR (#802) was merged into master
by accident before the release was finalized. **Do not merge until 6.5.0 is
done.** 6.5.0 is currently hidden from the docs Release Notes navigation on
master (via `HIDDEN_VERSIONS` in `docs/release-notes/navigation.tsx`); once this
merges for real, remove it from that list to surface 6.5.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)