### PR TITLE
ci: tag build-in-public release posts with #release-post

### DIFF
--- a/.github/workflows/publish-release-announcements.yml
+++ b/.github/workflows/publish-release-announcements.yml
@@ -62,9 +62,9 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_BUILD_IN_PUBLIC_WEBHOOK }}
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
-          # Append the #public tag — a downstream job watches for it and cross-posts to X / LinkedIn.
+          # Append the #release-post tag — a downstream job watches for it and cross-posts to X / LinkedIn.
           jq -n --rawfile body "$BASE/social.md" \
-            '{ "text": (($body | rtrimstr("\n")) + "\n\n#public") }' \
+            '{ "text": (($body | rtrimstr("\n")) + "\n\n#release-post") }' \
             | curl -sf -X POST "$SLACK_WEBHOOK" \
                 -H "Content-Type: application/json" \
                 -d @-


### PR DESCRIPTION
## What

The publish workflow appends a tag to the `social.md` body before posting it to `#build-in-public`. That tag was `#public`; it is now `#release-post`.

```diff
-            '{ "text": (($body | rtrimstr("\n")) + "\n\n#public") }' \
+            '{ "text": (($body | rtrimstr("\n")) + "\n\n#release-post") }' \
```

## Why

The tag is what the downstream cross-posting job watches to pick a message up and push it to X and LinkedIn. `#release-post` is the tag that job expects for release announcements.

## Notes

For `pull_request` events GitHub reads workflow files from `master` as of when the event fires, not from the PR branch. So this needs to be on `master` before the next `release-announcements/X` PR merges, otherwise that release still posts under `#public`.

Verified the jq payload still builds:

```json
{ "text": "Post body line one.\nLine two.\n\n#release-post" }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)