### PR TITLE
ci: send release announcements as a person, not as the Slack app

### DIFF
--- a/.github/scripts/post-to-slack.sh
+++ b/.github/scripts/post-to-slack.sh
@@ -1,19 +1,17 @@
 #!/usr/bin/env bash
 #
-# Posts one message to Slack, given the text as $1.
+# Posts one message to Slack as a person, given the text as $1 and optionally a
+# Block Kit blocks array as $2. With blocks, $1 is what shows in notifications
+# and in clients that cannot render them.
 #
-# With SLACK_USER_TOKEN set, the message is sent through chat.postMessage and
-# arrives from that person, with their name and avatar and no app badge. That
-# needs CHANNEL_ID too, because the Web API takes a channel id rather than a
-# webhook url. The token is an xoxp- user token with the chat:write user scope,
-# and the person it belongs to has to be a member of the channel.
-#
-# Without a user token it falls back to SLACK_WEBHOOK, which posts under the
-# Slack app's own name. Each workspace needs its own token, so the fallback is
-# what keeps a channel publishing while its token is still missing.
+# SLACK_USER_TOKEN is an xoxp- user token with the chat:write user scope, and
+# CHANNEL_ID is the channel to post into, because the Web API takes an id rather
+# than a webhook url. The person the token belongs to has to be a member of that
+# channel. Each workspace needs its own token.
 set -euo pipefail
 
-TEXT="$1"
+TEXT="${1:-}"
+BLOCKS="${2:-}"
 
 # Overridable so the flow can be exercised against a local mock server.
 SLACK_API="${SLACK_API:-https://slack.com/api}"
@@ -23,41 +21,39 @@ if [ -z "$TEXT" ]; then
   exit 1
 fi
 
-if [ -n "${SLACK_USER_TOKEN:-}" ]; then
-  if [ -z "${CHANNEL_ID:-}" ]; then
-    echo "SLACK_USER_TOKEN is set but CHANNEL_ID is empty, so there is nowhere to post." >&2
-    exit 1
-  fi
-
-  RESPONSE=$(
-    jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" \
-      '{ "channel": $channel, "text": $text }' \
-      | curl -sS -X POST "$SLACK_API/chat.postMessage" \
-          -H "Authorization: Bearer $SLACK_USER_TOKEN" \
-          -H "Content-Type: application/json; charset=utf-8" \
-          -d @-
-  )
-
-  # chat.postMessage answers 200 even when it refuses the message, so curl's
-  # exit code proves nothing and the body has to be read. Failing loudly here
-  # matters: the caller tags the version as published once these steps pass.
-  if [ "$(printf '%s' "$RESPONSE" | jq -r '.ok')" != "true" ]; then
-    echo "Slack refused the message: $(printf '%s' "$RESPONSE" | jq -r '.error // "unknown error"')" >&2
-    exit 1
-  fi
-
-  echo "Posted to $CHANNEL_ID as the user behind SLACK_USER_TOKEN."
-  exit 0
-fi
-
-if [ -z "${SLACK_WEBHOOK:-}" ]; then
-  echo "Neither SLACK_USER_TOKEN nor SLACK_WEBHOOK is set, so the message cannot be sent." >&2
+if [ -z "${SLACK_USER_TOKEN:-}" ]; then
+  echo "SLACK_USER_TOKEN is empty, so there is no way to post." >&2
   exit 1
 fi
 
-jq -n --arg text "$TEXT" '{ "text": $text }' \
-  | curl -sf -X POST "$SLACK_WEBHOOK" \
-      -H "Content-Type: application/json" \
-      -d @-
+if [ -z "${CHANNEL_ID:-}" ]; then
+  echo "CHANNEL_ID is empty, so there is nowhere to post." >&2
+  exit 1
+fi
 
-echo "Posted through the incoming webhook, under the Slack app's name."
+if [ -n "$BLOCKS" ]; then
+  PAYLOAD=$(jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" --argjson blocks "$BLOCKS" \
+    '{ "channel": $channel, "text": $text, "blocks": $blocks }')
+else
+  PAYLOAD=$(jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" \
+    '{ "channel": $channel, "text": $text }')
+fi
+
+RESPONSE=$(
+  printf '%s' "$PAYLOAD" \
+    | curl -sS -X POST "$SLACK_API/chat.postMessage" \
+        -H "Authorization: Bearer $SLACK_USER_TOKEN" \
+        -H "Content-Type: application/json; charset=utf-8" \
+        -d @-
+)
+
+# chat.postMessage answers 200 even when it refuses the message, so curl's exit
+# code proves nothing and the body has to be read. Failing loudly matters most
+# in the publish workflow, which tags the version as published once its posting
+# steps pass, and that tag makes every later run skip.
+if [ "$(printf '%s' "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+  echo "Slack refused the message: $(printf '%s' "$RESPONSE" | jq -r '.error // "unknown error"')" >&2
+  exit 1
+fi
+
+echo "Posted to $CHANNEL_ID."

--- a/.github/scripts/post-to-slack.sh
+++ b/.github/scripts/post-to-slack.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Posts one message to Slack, given the text as $1.
+#
+# With SLACK_USER_TOKEN set, the message is sent through chat.postMessage and
+# arrives from that person, with their name and avatar and no app badge. That
+# needs CHANNEL_ID too, because the Web API takes a channel id rather than a
+# webhook url. The token is an xoxp- user token with the chat:write user scope,
+# and the person it belongs to has to be a member of the channel.
+#
+# Without a user token it falls back to SLACK_WEBHOOK, which posts under the
+# Slack app's own name. Each workspace needs its own token, so the fallback is
+# what keeps a channel publishing while its token is still missing.
+set -euo pipefail
+
+TEXT="$1"
+
+# Overridable so the flow can be exercised against a local mock server.
+SLACK_API="${SLACK_API:-https://slack.com/api}"
+
+if [ -z "$TEXT" ]; then
+  echo "Refusing to post an empty message." >&2
+  exit 1
+fi
+
+if [ -n "${SLACK_USER_TOKEN:-}" ]; then
+  if [ -z "${CHANNEL_ID:-}" ]; then
+    echo "SLACK_USER_TOKEN is set but CHANNEL_ID is empty, so there is nowhere to post." >&2
+    exit 1
+  fi
+
+  RESPONSE=$(
+    jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" \
+      '{ "channel": $channel, "text": $text }' \
+      | curl -sS -X POST "$SLACK_API/chat.postMessage" \
+          -H "Authorization: Bearer $SLACK_USER_TOKEN" \
+          -H "Content-Type: application/json; charset=utf-8" \
+          -d @-
+  )
+
+  # chat.postMessage answers 200 even when it refuses the message, so curl's
+  # exit code proves nothing and the body has to be read. Failing loudly here
+  # matters: the caller tags the version as published once these steps pass.
+  if [ "$(printf '%s' "$RESPONSE" | jq -r '.ok')" != "true" ]; then
+    echo "Slack refused the message: $(printf '%s' "$RESPONSE" | jq -r '.error // "unknown error"')" >&2
+    exit 1
+  fi
+
+  echo "Posted to $CHANNEL_ID as the user behind SLACK_USER_TOKEN."
+  exit 0
+fi
+
+if [ -z "${SLACK_WEBHOOK:-}" ]; then
+  echo "Neither SLACK_USER_TOKEN nor SLACK_WEBHOOK is set, so the message cannot be sent." >&2
+  exit 1
+fi
+
+jq -n --arg text "$TEXT" '{ "text": $text }' \
+  | curl -sf -X POST "$SLACK_WEBHOOK" \
+      -H "Content-Type: application/json" \
+      -d @-
+
+echo "Posted through the incoming webhook, under the Slack app's name."

--- a/.github/scripts/post-to-slack.sh
+++ b/.github/scripts/post-to-slack.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 #
-# Posts one message to Slack as a person, given the text as $1 and optionally a
-# Block Kit blocks array as $2. With blocks, $1 is what shows in notifications
-# and in clients that cannot render them.
+# Posts one message to Slack as a person, given the text as $1.
 #
 # SLACK_USER_TOKEN is an xoxp- user token with the chat:write user scope, and
 # CHANNEL_ID is the channel to post into, because the Web API takes an id rather
@@ -11,7 +9,6 @@
 set -euo pipefail
 
 TEXT="${1:-}"
-BLOCKS="${2:-}"
 
 # Overridable so the flow can be exercised against a local mock server.
 SLACK_API="${SLACK_API:-https://slack.com/api}"
@@ -31,16 +28,9 @@ if [ -z "${CHANNEL_ID:-}" ]; then
   exit 1
 fi
 
-if [ -n "$BLOCKS" ]; then
-  PAYLOAD=$(jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" --argjson blocks "$BLOCKS" \
-    '{ "channel": $channel, "text": $text, "blocks": $blocks }')
-else
-  PAYLOAD=$(jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" \
-    '{ "channel": $channel, "text": $text }')
-fi
-
 RESPONSE=$(
-  printf '%s' "$PAYLOAD" \
+  jq -n --arg channel "$CHANNEL_ID" --arg text "$TEXT" \
+    '{ "channel": $channel, "text": $text }' \
     | curl -sS -X POST "$SLACK_API/chat.postMessage" \
         -H "Authorization: Bearer $SLACK_USER_TOKEN" \
         -H "Content-Type: application/json; charset=utf-8" \
@@ -48,9 +38,9 @@ RESPONSE=$(
 )
 
 # chat.postMessage answers 200 even when it refuses the message, so curl's exit
-# code proves nothing and the body has to be read. Failing loudly matters most
-# in the publish workflow, which tags the version as published once its posting
-# steps pass, and that tag makes every later run skip.
+# code proves nothing and the body has to be read. Failing loudly matters here:
+# the workflow tags the version as published once both posts pass, and that tag
+# makes every later run skip.
 if [ "$(printf '%s' "$RESPONSE" | jq -r '.ok')" != "true" ]; then
   echo "Slack refused the message: $(printf '%s' "$RESPONSE" | jq -r '.error // "unknown error"')" >&2
   exit 1

--- a/.github/workflows/publish-release-announcements.yml
+++ b/.github/workflows/publish-release-announcements.yml
@@ -60,7 +60,7 @@ jobs:
         if: steps.guard.outputs.already == 'false'
         env:
           SLACK_USER_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
-          CHANNEL_ID: C09LLSR96KU
+          CHANNEL_ID: C09LLSR96KU # #build-in-public
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
           # Append the #release-post tag — a downstream job watches for it and cross-posts to X / LinkedIn.
@@ -71,10 +71,9 @@ jobs:
       - name: Post Slack announcement to community Announcements
         if: steps.guard.outputs.already == 'false'
         env:
-          # The community workspace is a separate Slack, so it has its own token
-          # and its channel id lives in a repository variable.
+          # The community workspace is a separate Slack, so it has its own token.
           SLACK_USER_TOKEN: ${{ secrets.SLACK_COMMUNITY_USER_TOKEN }}
-          CHANNEL_ID: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}
+          CHANNEL_ID: C0149TWSS0Z # #announcements, in webiny-community
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
           # Convert literal @channel to the Slack broadcast token so the ping fires.

--- a/.github/workflows/publish-release-announcements.yml
+++ b/.github/workflows/publish-release-announcements.yml
@@ -61,7 +61,6 @@ jobs:
         env:
           SLACK_USER_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
           CHANNEL_ID: C09LLSR96KU
-          SLACK_WEBHOOK: ${{ secrets.SLACK_BUILD_IN_PUBLIC_WEBHOOK }}
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
           # Append the #release-post tag — a downstream job watches for it and cross-posts to X / LinkedIn.
@@ -72,12 +71,10 @@ jobs:
       - name: Post Slack announcement to community Announcements
         if: steps.guard.outputs.already == 'false'
         env:
-          # The community workspace is a separate Slack, so it needs its own user
-          # token and channel id. Until both are set, this post keeps going out
-          # through the webhook under the app's name.
+          # The community workspace is a separate Slack, so it has its own token
+          # and its channel id lives in a repository variable.
           SLACK_USER_TOKEN: ${{ secrets.SLACK_COMMUNITY_USER_TOKEN }}
           CHANNEL_ID: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}
-          SLACK_WEBHOOK: ${{ secrets.SLACK_COMMUNITY_ANNOUNCEMENTS_WEBHOOK }}
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
           # Convert literal @channel to the Slack broadcast token so the ping fires.

--- a/.github/workflows/publish-release-announcements.yml
+++ b/.github/workflows/publish-release-announcements.yml
@@ -59,28 +59,31 @@ jobs:
       - name: "Post social announcement to #build-in-public"
         if: steps.guard.outputs.already == 'false'
         env:
+          SLACK_USER_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
+          CHANNEL_ID: C09LLSR96KU
           SLACK_WEBHOOK: ${{ secrets.SLACK_BUILD_IN_PUBLIC_WEBHOOK }}
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
           # Append the #release-post tag — a downstream job watches for it and cross-posts to X / LinkedIn.
-          jq -n --rawfile body "$BASE/social.md" \
-            '{ "text": (($body | rtrimstr("\n")) + "\n\n#release-post") }' \
-            | curl -sf -X POST "$SLACK_WEBHOOK" \
-                -H "Content-Type: application/json" \
-                -d @-
+          TEXT=$(jq -rn --rawfile body "$BASE/social.md" \
+            '($body | rtrimstr("\n")) + "\n\n#release-post"')
+          .github/scripts/post-to-slack.sh "$TEXT"
 
       - name: Post Slack announcement to community Announcements
         if: steps.guard.outputs.already == 'false'
         env:
+          # The community workspace is a separate Slack, so it needs its own user
+          # token and channel id. Until both are set, this post keeps going out
+          # through the webhook under the app's name.
+          SLACK_USER_TOKEN: ${{ secrets.SLACK_COMMUNITY_USER_TOKEN }}
+          CHANNEL_ID: ${{ vars.SLACK_COMMUNITY_CHANNEL_ID }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_COMMUNITY_ANNOUNCEMENTS_WEBHOOK }}
         run: |
           BASE="docs/release-notes/${{ env.VERSION }}/announcements"
           # Convert literal @channel to the Slack broadcast token so the ping fires.
-          jq -n --rawfile body "$BASE/slack.md" \
-            '{ "text": ($body | gsub("@channel"; "<!channel>")) }' \
-            | curl -sf -X POST "$SLACK_WEBHOOK" \
-                -H "Content-Type: application/json" \
-                -d @-
+          TEXT=$(jq -rn --rawfile body "$BASE/slack.md" \
+            '$body | gsub("@channel"; "<!channel>")')
+          .github/scripts/post-to-slack.sh "$TEXT"
 
       # Written only after both posts succeed, so a partial failure stays retryable.
       - name: Mark this version as published

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -66,7 +66,8 @@ jobs:
 
       - name: Send Slack announcement
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
+          SLACK_USER_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
+          CHANNEL_ID: C017C8CC4KA # #release
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           VERSION="${{ env.VERSION }}"
@@ -76,14 +77,12 @@ jobs:
           SOCIAL_URL="${REPO_URL}/blob/${ANNOUNCE_BRANCH}/${BASE}/social.md"
           PR_URL="${{ env.PR_URL }}"
 
-          jq -n \
+          BLOCKS=$(jq -c -n \
             --arg version "$VERSION" \
             --arg pr_url "$PR_URL" \
             --arg slack_url "$SLACK_URL" \
             --arg social_url "$SOCIAL_URL" \
-            '{
-              "text": ("Release " + $version + " announcements ready for review"),
-              "blocks": [
+            '[
                 {
                   "type": "section",
                   "text": {
@@ -107,7 +106,7 @@ jobs:
                     }
                   ]
                 }
-              ]
-            }' | curl -s -X POST "$SLACK_WEBHOOK" \
-              -H "Content-Type: application/json" \
-              -d @-
+              ]')
+
+          .github/scripts/post-to-slack.sh \
+            "Release ${VERSION} announcements ready for review" "$BLOCKS"

--- a/.github/workflows/release-announcements.yml
+++ b/.github/workflows/release-announcements.yml
@@ -66,8 +66,7 @@ jobs:
 
       - name: Send Slack announcement
         env:
-          SLACK_USER_TOKEN: ${{ secrets.SLACK_USER_TOKEN }}
-          CHANNEL_ID: C017C8CC4KA # #release
+          SLACK_WEBHOOK: ${{ secrets.SLACK_RELEASE_CHANNEL_WEBHOOK }}
           REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
           VERSION="${{ env.VERSION }}"
@@ -77,12 +76,14 @@ jobs:
           SOCIAL_URL="${REPO_URL}/blob/${ANNOUNCE_BRANCH}/${BASE}/social.md"
           PR_URL="${{ env.PR_URL }}"
 
-          BLOCKS=$(jq -c -n \
+          jq -n \
             --arg version "$VERSION" \
             --arg pr_url "$PR_URL" \
             --arg slack_url "$SLACK_URL" \
             --arg social_url "$SOCIAL_URL" \
-            '[
+            '{
+              "text": ("Release " + $version + " announcements ready for review"),
+              "blocks": [
                 {
                   "type": "section",
                   "text": {
@@ -106,7 +107,7 @@ jobs:
                     }
                   ]
                 }
-              ]')
-
-          .github/scripts/post-to-slack.sh \
-            "Release ${VERSION} announcements ready for review" "$BLOCKS"
+              ]
+            }' | curl -s -X POST "$SLACK_WEBHOOK" \
+              -H "Content-Type: application/json" \
+              -d @-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,11 @@ Only two files are generated: `slack.md` and `social.md`. Follow-up tweets (`twe
 - For `pull_request` events, GitHub reads workflow files from `master` as it exists when the event fires, not from the PR branch. Changes to the publish workflow must be on `master` before the announcements PR merges.
 - A stale announcements PR for an old release is live ammunition. Merging one announces a months-old release to the community channel with an `@channel` ping, and the tag guard does not help because that version was never tagged. Close stale announcements PRs, do not merge them. The job is gated on `merged == true`, so closing fires nothing.
 
-**Secrets:** `SLACK_BUILD_IN_PUBLIC_WEBHOOK` and `SLACK_COMMUNITY_ANNOUNCEMENTS_WEBHOOK`, plus `SLACK_RELEASE_CHANNEL_WEBHOOK` for the review ping. The two publish webhooks come from separate Slack apps, because the internal and community channels are in different workspaces.
+**Who the announcements come from:** both publish steps go through `.github/scripts/post-to-slack.sh`. When a user token is available it calls `chat.postMessage`, so the announcement arrives from that person rather than from an app. When it is not, it falls back to the channel's incoming webhook and posts under the app's name. A webhook cannot be made to look like a person: `username` and `icon_url` in the payload only apply to legacy custom-integration webhooks, and app webhooks ignore them silently.
+
+**Secrets:** `SLACK_USER_TOKEN` and `SLACK_COMMUNITY_USER_TOKEN` are `xoxp-` user tokens with the `chat:write` user scope, one per workspace, and the person behind each has to be a member of the channel. `SLACK_BUILD_IN_PUBLIC_WEBHOOK` and `SLACK_COMMUNITY_ANNOUNCEMENTS_WEBHOOK` are the fallbacks, and `SLACK_RELEASE_CHANNEL_WEBHOOK` sends the review ping. The two publish webhooks come from separate Slack apps, because the internal and community channels are in different workspaces.
+
+**Channel ids:** `#build-in-public` is `C09LLSR96KU`, hardcoded in the publish workflow. The community channel id lives in the `SLACK_COMMUNITY_CHANNEL_ID` repository variable, since that workspace is administered separately. A user token set without its channel id fails the step rather than posting to the wrong place.
 
 ### Validation and Quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,13 +50,13 @@ Only two files are generated: `slack.md` and `social.md`. Follow-up tweets (`twe
 - For `pull_request` events, GitHub reads workflow files from `master` as it exists when the event fires, not from the PR branch. Changes to the publish workflow must be on `master` before the announcements PR merges.
 - A stale announcements PR for an old release is live ammunition. Merging one announces a months-old release to the community channel with an `@channel` ping, and the tag guard does not help because that version was never tagged. Close stale announcements PRs, do not merge them. The job is gated on `merged == true`, so closing fires nothing.
 
-**Who the announcements come from:** every Slack post, the review ping included, goes through `.github/scripts/post-to-slack.sh`, which calls `chat.postMessage` with a user token. Messages arrive from that person rather than from an app. Incoming webhooks are gone and are not worth going back to: a webhook cannot be made to look like a person, since `username` and `icon_url` only apply to legacy custom-integration webhooks and app webhooks ignore them silently.
+**Who the announcements come from:** the two published announcements go through `.github/scripts/post-to-slack.sh`, which calls `chat.postMessage` with a user token, so they arrive from that person rather than from an app. A webhook cannot do this: `username` and `icon_url` only apply to legacy custom-integration webhooks, and app webhooks ignore them silently. The script also fails the step when Slack refuses, since `chat.postMessage` answers 200 with `ok: false` in the body.
 
-The script takes the message text as its first argument and an optional Block Kit array as its second. With blocks, the text is the notification fallback. It fails the step when Slack refuses, which a webhook could not do, because `chat.postMessage` answers 200 with `ok: false` in the body.
+The review ping stays on its webhook. It is internal, it posts Block Kit, and it does not matter who it comes from.
 
-**Secrets:** `SLACK_USER_TOKEN` for the Webiny workspace and `SLACK_COMMUNITY_USER_TOKEN` for the community one. Both are `xoxp-` user tokens with the `chat:write` user scope, and the person behind each has to be a member of the channels it posts to. Two tokens because the internal and community channels live in different workspaces.
+**Secrets:** `SLACK_USER_TOKEN` for the Webiny workspace and `SLACK_COMMUNITY_USER_TOKEN` for the community one, both `xoxp-` user tokens with the `chat:write` user scope, and the person behind each has to be a member of the channel. Two tokens because the two channels live in different workspaces. `SLACK_RELEASE_CHANNEL_WEBHOOK` still sends the review ping.
 
-**Channel ids** are hardcoded in the workflows, since they are not secret and never change: `#build-in-public` is `C09LLSR96KU` and `#release` is `C017C8CC4KA` in the Webiny workspace, `#announcements` is `C0149TWSS0Z` in webiny-community.
+**Channel ids** are hardcoded in the publish workflow, since they are not secret and never change: `#build-in-public` is `C09LLSR96KU` in the Webiny workspace, `#announcements` is `C0149TWSS0Z` in webiny-community. The review ping has no channel id anywhere, because its webhook url has the channel baked in.
 
 ### Validation and Quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,13 @@ Only two files are generated: `slack.md` and `social.md`. Follow-up tweets (`twe
 - For `pull_request` events, GitHub reads workflow files from `master` as it exists when the event fires, not from the PR branch. Changes to the publish workflow must be on `master` before the announcements PR merges.
 - A stale announcements PR for an old release is live ammunition. Merging one announces a months-old release to the community channel with an `@channel` ping, and the tag guard does not help because that version was never tagged. Close stale announcements PRs, do not merge them. The job is gated on `merged == true`, so closing fires nothing.
 
-**Who the announcements come from:** both publish steps go through `.github/scripts/post-to-slack.sh`. When a user token is available it calls `chat.postMessage`, so the announcement arrives from that person rather than from an app. When it is not, it falls back to the channel's incoming webhook and posts under the app's name. A webhook cannot be made to look like a person: `username` and `icon_url` in the payload only apply to legacy custom-integration webhooks, and app webhooks ignore them silently.
+**Who the announcements come from:** every Slack post, the review ping included, goes through `.github/scripts/post-to-slack.sh`, which calls `chat.postMessage` with a user token. Messages arrive from that person rather than from an app. Incoming webhooks are gone and are not worth going back to: a webhook cannot be made to look like a person, since `username` and `icon_url` only apply to legacy custom-integration webhooks and app webhooks ignore them silently.
 
-**Secrets:** `SLACK_USER_TOKEN` and `SLACK_COMMUNITY_USER_TOKEN` are `xoxp-` user tokens with the `chat:write` user scope, one per workspace, and the person behind each has to be a member of the channel. `SLACK_BUILD_IN_PUBLIC_WEBHOOK` and `SLACK_COMMUNITY_ANNOUNCEMENTS_WEBHOOK` are the fallbacks, and `SLACK_RELEASE_CHANNEL_WEBHOOK` sends the review ping. The two publish webhooks come from separate Slack apps, because the internal and community channels are in different workspaces.
+The script takes the message text as its first argument and an optional Block Kit array as its second. With blocks, the text is the notification fallback. It fails the step when Slack refuses, which a webhook could not do, because `chat.postMessage` answers 200 with `ok: false` in the body.
 
-**Channel ids:** `#build-in-public` is `C09LLSR96KU`, hardcoded in the publish workflow. The community channel id lives in the `SLACK_COMMUNITY_CHANNEL_ID` repository variable, since that workspace is administered separately. A user token set without its channel id fails the step rather than posting to the wrong place.
+**Secrets:** `SLACK_USER_TOKEN` for the Webiny workspace and `SLACK_COMMUNITY_USER_TOKEN` for the community one. Both are `xoxp-` user tokens with the `chat:write` user scope, and the person behind each has to be a member of the channels it posts to. Two tokens because the internal and community channels live in different workspaces.
+
+**Channel ids:** `#build-in-public` is `C09LLSR96KU` and `#release` is `C017C8CC4KA`, both hardcoded in the workflows. The community channel id lives in the `SLACK_COMMUNITY_CHANNEL_ID` repository variable, since that workspace is administered separately.
 
 ### Validation and Quality
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,7 @@ The script takes the message text as its first argument and an optional Block Ki
 
 **Secrets:** `SLACK_USER_TOKEN` for the Webiny workspace and `SLACK_COMMUNITY_USER_TOKEN` for the community one. Both are `xoxp-` user tokens with the `chat:write` user scope, and the person behind each has to be a member of the channels it posts to. Two tokens because the internal and community channels live in different workspaces.
 
-**Channel ids:** `#build-in-public` is `C09LLSR96KU` and `#release` is `C017C8CC4KA`, both hardcoded in the workflows. The community channel id lives in the `SLACK_COMMUNITY_CHANNEL_ID` repository variable, since that workspace is administered separately.
+**Channel ids** are hardcoded in the workflows, since they are not secret and never change: `#build-in-public` is `C09LLSR96KU` and `#release` is `C017C8CC4KA` in the Webiny workspace, `#announcements` is `C0149TWSS0Z` in webiny-community.
 
 ### Validation and Quality
 


### PR DESCRIPTION
## What

The two published announcements now go through `.github/scripts/post-to-slack.sh`, which calls `chat.postMessage` with an `xoxp-` user token. They arrive from a person, with a real name and avatar and no app badge.

- `social.md` to `#build-in-public` (`C09LLSR96KU`)
- `slack.md` to `#announcements` in webiny-community (`C0149TWSS0Z`)

The `#release` review ping in `release-announcements.yml` is untouched and stays on `SLACK_RELEASE_CHANNEL_WEBHOOK`. It is internal and it does not matter who it comes from.

## Why

Announcements read better coming from a person than from an app, and a webhook cannot be made to look like one. `username` and `icon_url` in a webhook payload only apply to legacy custom-integration webhooks; app webhooks drop both fields silently and the run still reports success. A user token is the only route.

The Slack apps behind both announcement webhooks have since been deleted, so those two urls post nowhere regardless.

## Worth reviewing

`chat.postMessage` answers 200 even when it refuses a message, so the script reads `ok` out of the body rather than trusting curl's exit code. The workflow tags the version as `announcements-published/<version>` once both posts pass, and that tag makes every later run skip, so a swallowed failure would mean no announcement and no way to retry.

## Setup needed

Two secrets, one user token per workspace. Each app needs a **User** Token Scope of `chat:write`, not a bot scope, and the token owner has to be a member of the channel.

- `SLACK_USER_TOKEN` — Webiny workspace
- `SLACK_COMMUNITY_USER_TOKEN` — webiny-community workspace

Channel ids are hardcoded, since they are not secret and do not change. `SLACK_BUILD_IN_PUBLIC_WEBHOOK` and `SLACK_COMMUNITY_ANNOUNCEMENTS_WEBHOOK` are dead and can be deleted; `SLACK_RELEASE_CHANNEL_WEBHOOK` is still in use.

## Notes

Exercised against a local mock Slack: posts land with the right channel and body, a refusal (`not_in_channel`) fails the step, and a missing token or channel id fails before any request goes out. Rebuilt the message text from the real 6.4.11 announcements too, so the `#release-post` tag still lands at the end of the social post and `@channel` still becomes `<!channel>` in the community one.

For `pull_request` events GitHub reads workflow files from `master` as of when the event fires, not from the PR branch. This needs to be on `master` before the `release-announcements/6.4.11` PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)